### PR TITLE
Fix unmatched main tag in home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,18 @@
 "use client";
-import { Card } from "@/components/ui/card";
-import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { AuthButtons, HeroAuthButtons } from "@/components/auth-buttons";
+import Image from "next/image";
+import Link from "next/link";
 import {
   Activity,
   Bot,
@@ -242,6 +250,8 @@ export default function Home() {
         <HeroAuthButtons />
       </div>
 
+      <main>
+
           <Separator className="my-12 bg-slate-800" />
 
           <section className="mx-auto max-w-6xl space-y-8">
@@ -406,8 +416,7 @@ export default function Home() {
               </Button>
             </div>
           </section>
-        </main>
-      </div>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add the missing `<main>` wrapper around the home page sections so the JSX tree matches its closing tag
- import the badge, card helpers, and Next.js `Image` component that the page uses to satisfy linting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d836db2e10832b8d9367482b8f1782