### PR TITLE
Fix dashboard component import aliases

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
-import { ChartAreaInteractive } from "@//components/chart-area-interactive"
-import { DataTable } from "@//components/data-table"
-import { SectionCards } from "@//components/section-cards"
+import { ChartAreaInteractive } from "@/components/chart-area-interactive"
+import { DataTable } from "@/components/data-table"
+import { SectionCards } from "@/components/section-cards"
 import data from "@/app/dashboard/data.json"
 
 export default function Page() {


### PR DESCRIPTION
## Summary
- update the dashboard page to import components from the correct alias path

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d840a9da68832b9d8722cf4f0a9391