### PR TITLE
Fix Next.js import ordering on landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
+import Image from "next/image";
 import {
   Activity,
   Bot,


### PR DESCRIPTION
## Summary
- reorder the `next/link` and `next/image` imports on the landing page to match project conventions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d844872f20832ba928d0e5a0f0c26e