### PR TITLE
fix: clean auth form lint warnings

### DIFF
--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -34,7 +34,8 @@ export default function SignInPage() {
             } else {
                 router.push("/dashboard");
             }
-        } catch (err) {
+        } catch (error) {
+            console.error(error);
             setError("An unexpected error occurred");
         } finally {
             setIsLoading(false);

--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -8,7 +8,6 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
@@ -63,7 +62,8 @@ export default function SignUpPage() {
             } else {
                 router.push("/dashboard");
             }
-        } catch (err) {
+        } catch (error) {
+            console.error(error);
             setError("An unexpected error occurred");
         } finally {
             setIsLoading(false);


### PR DESCRIPTION
## Summary
- log caught errors in the sign-in and sign-up forms so eslint no-unused-vars no longer flags the catch parameter
- drop the unused `Label` import from the sign-up page
- verified the site header still only pulls in the separator and sidebar trigger components

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8464a55ac832bbe3feab4252e497b