### PR TITLE
Add comprehensive app schema tables and RLS policies

### DIFF
--- a/db/schema/app.ts
+++ b/db/schema/app.ts
@@ -1,0 +1,567 @@
+import { sql } from 'drizzle-orm';
+import {
+    boolean,
+    index,
+    inet,
+    integer,
+    jsonb,
+    numeric,
+    pgSchema,
+    text,
+    timestamp,
+    uuid,
+    varchar,
+    date,
+    bigint,
+} from 'drizzle-orm/pg-core';
+
+export const appSchema = pgSchema('app');
+
+export const users = appSchema.table(
+    'users',
+    {
+        id: uuid('id').defaultRandom().primaryKey(),
+        username: varchar('username', { length: 50 }).notNull().unique(),
+        email: varchar('email', { length: 100 }).notNull().unique(),
+        passwordHash: varchar('password_hash', { length: 255 }).notNull(),
+        role: varchar('role', { length: 20 }).notNull(),
+        fullName: varchar('full_name', { length: 100 }).notNull(),
+        phone: varchar('phone', { length: 20 }),
+        isActive: boolean('is_active').default(true),
+        lastLogin: timestamp('last_login'),
+        createdAt: timestamp('created_at').defaultNow().notNull(),
+        updatedAt: timestamp('updated_at').defaultNow().notNull(),
+    },
+    (table) => ({
+        usernameIdx: index('idx_users_username').on(table.username),
+        emailIdx: index('idx_users_email').on(table.email),
+    }),
+);
+
+export const customers = appSchema.table(
+    'customers',
+    {
+        id: uuid('id').defaultRandom().primaryKey(),
+        name: varchar('name', { length: 100 }).notNull(),
+        phone: varchar('phone', { length: 20 }).notNull().unique(),
+        email: varchar('email', { length: 100 }),
+        address: text('address'),
+        companyName: varchar('company_name', { length: 100 }),
+        customerType: varchar('customer_type', { length: 20 }).default('individual').notNull(),
+        notes: text('notes'),
+        createdBy: uuid('created_by').references(() => users.id),
+        createdAt: timestamp('created_at').defaultNow().notNull(),
+        updatedAt: timestamp('updated_at').defaultNow().notNull(),
+    },
+    (table) => ({
+        phoneIdx: index('idx_customers_phone').on(table.phone),
+        nameIdx: index('idx_customers_name').on(table.name),
+        emailIdx: index('idx_customers_email').on(table.email),
+        createdAtIdx: index('idx_customers_created_at').on(table.createdAt),
+    }),
+);
+
+export const products = appSchema.table(
+    'products',
+    {
+        id: uuid('id').defaultRandom().primaryKey(),
+        name: varchar('name', { length: 100 }).notNull(),
+        description: text('description'),
+        category: varchar('category', { length: 50 }).notNull(),
+        sku: varchar('sku', { length: 50 }).unique(),
+        barcode: varchar('barcode', { length: 50 }),
+        price: numeric('price', { precision: 10, scale: 2 }).notNull(),
+        cost: numeric('cost', { precision: 10, scale: 2 }).notNull(),
+        stockQuantity: integer('stock_quantity').default(0).notNull(),
+        reorderLevel: integer('reorder_level').default(10).notNull(),
+        unitOfMeasure: varchar('unit_of_measure', { length: 20 }).default('unit').notNull(),
+        isActive: boolean('is_active').default(true),
+        createdBy: uuid('created_by').references(() => users.id),
+        createdAt: timestamp('created_at').defaultNow().notNull(),
+        updatedAt: timestamp('updated_at').defaultNow().notNull(),
+    },
+    (table) => ({
+        skuIdx: index('idx_products_sku').on(table.sku),
+        categoryIdx: index('idx_products_category').on(table.category),
+        nameIdx: index('idx_products_name').on(table.name),
+        stockIdx: index('idx_products_stock_quantity').on(table.stockQuantity),
+    }),
+);
+
+export const tickets = appSchema.table(
+    'tickets',
+    {
+        id: uuid('id').defaultRandom().primaryKey(),
+        ticketNumber: varchar('ticket_number', { length: 20 }).notNull().unique(),
+        customerId: uuid('customer_id')
+            .notNull()
+            .references(() => customers.id, { onDelete: 'cascade' }),
+        deviceType: varchar('device_type', { length: 50 }).notNull(),
+        deviceModel: varchar('device_model', { length: 100 }).notNull(),
+        serialNumber: varchar('serial_number', { length: 50 }),
+        problemDescription: text('problem_description').notNull(),
+        status: varchar('status', { length: 20 }).default('pending').notNull(),
+        priority: varchar('priority', { length: 20 }).default('normal').notNull(),
+        estimatedCost: numeric('estimated_cost', { precision: 10, scale: 2 }),
+        actualCost: numeric('actual_cost', { precision: 10, scale: 2 }),
+        estimatedCompletionDate: date('estimated_completion_date'),
+        technicianNotes: text('technician_notes'),
+        assignedTo: uuid('assigned_to').references(() => users.id),
+        createdBy: uuid('created_by').references(() => users.id),
+        createdAt: timestamp('created_at').defaultNow().notNull(),
+        updatedAt: timestamp('updated_at').defaultNow().notNull(),
+    },
+    (table) => ({
+        customerIdx: index('idx_tickets_customer_id').on(table.customerId),
+        statusIdx: index('idx_tickets_status').on(table.status),
+        assignedIdx: index('idx_tickets_assigned_to').on(table.assignedTo),
+        createdIdx: index('idx_tickets_created_at').on(table.createdAt),
+        numberIdx: index('idx_tickets_ticket_number').on(table.ticketNumber),
+    }),
+);
+
+export const ticketUpdates = appSchema.table('ticket_updates', {
+    id: uuid('id').defaultRandom().primaryKey(),
+    ticketId: uuid('ticket_id')
+        .notNull()
+        .references(() => tickets.id, { onDelete: 'cascade' }),
+    updateType: varchar('update_type', { length: 50 }).notNull(),
+    description: text('description'),
+    imageUrl: text('image_url'),
+    updatedBy: uuid('updated_by')
+        .notNull()
+        .references(() => users.id),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
+export const quotations = appSchema.table(
+    'quotations',
+    {
+        id: uuid('id').defaultRandom().primaryKey(),
+        quotationNumber: varchar('quotation_number', { length: 20 }).notNull().unique(),
+        customerId: uuid('customer_id')
+            .notNull()
+            .references(() => customers.id, { onDelete: 'cascade' }),
+        ticketId: uuid('ticket_id').references(() => tickets.id, { onDelete: 'set null' }),
+        validUntil: date('valid_until').notNull(),
+        status: varchar('status', { length: 20 }).default('draft').notNull(),
+        subtotal: numeric('subtotal', { precision: 10, scale: 2 }).notNull(),
+        taxRate: numeric('tax_rate', { precision: 5, scale: 2 }).default(sql`6.00`).notNull(),
+        taxAmount: numeric('tax_amount', { precision: 10, scale: 2 }).notNull(),
+        total: numeric('total', { precision: 10, scale: 2 }).notNull(),
+        notes: text('notes'),
+        terms: text('terms'),
+        createdBy: uuid('created_by')
+            .notNull()
+            .references(() => users.id),
+        createdAt: timestamp('created_at').defaultNow().notNull(),
+        updatedAt: timestamp('updated_at').defaultNow().notNull(),
+    },
+    (table) => ({
+        customerIdx: index('idx_quotations_customer_id').on(table.customerId),
+        statusIdx: index('idx_quotations_status').on(table.status),
+        validUntilIdx: index('idx_quotations_valid_until').on(table.validUntil),
+        numberIdx: index('idx_quotations_quotation_number').on(table.quotationNumber),
+    }),
+);
+
+export const quotationItems = appSchema.table('quotation_items', {
+    id: uuid('id').defaultRandom().primaryKey(),
+    quotationId: uuid('quotation_id')
+        .notNull()
+        .references(() => quotations.id, { onDelete: 'cascade' }),
+    productId: uuid('product_id').references(() => products.id, { onDelete: 'set null' }),
+    description: text('description').notNull(),
+    quantity: integer('quantity').notNull(),
+    unitPrice: numeric('unit_price', { precision: 10, scale: 2 }).notNull(),
+    discount: numeric('discount', { precision: 10, scale: 2 }).default(sql`0.00`).notNull(),
+    totalPrice: numeric('total_price', { precision: 10, scale: 2 }).notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
+export const invoices = appSchema.table(
+    'invoices',
+    {
+        id: uuid('id').defaultRandom().primaryKey(),
+        invoiceNumber: varchar('invoice_number', { length: 20 }).notNull().unique(),
+        customerId: uuid('customer_id')
+            .notNull()
+            .references(() => customers.id, { onDelete: 'cascade' }),
+        ticketId: uuid('ticket_id').references(() => tickets.id, { onDelete: 'set null' }),
+        quotationId: uuid('quotation_id').references(() => quotations.id, { onDelete: 'set null' }),
+        invoiceDate: date('invoice_date').default(sql`CURRENT_DATE`).notNull(),
+        dueDate: date('due_date').notNull(),
+        status: varchar('status', { length: 20 }).default('draft').notNull(),
+        subtotal: numeric('subtotal', { precision: 10, scale: 2 }).notNull(),
+        taxRate: numeric('tax_rate', { precision: 5, scale: 2 }).default(sql`6.00`).notNull(),
+        taxAmount: numeric('tax_amount', { precision: 10, scale: 2 }).notNull(),
+        total: numeric('total', { precision: 10, scale: 2 }).notNull(),
+        paidAmount: numeric('paid_amount', { precision: 10, scale: 2 }).default(sql`0.00`).notNull(),
+        balance: numeric('balance', { precision: 10, scale: 2 }).generatedAlwaysAs(
+            sql`total - paid_amount`,
+            { stored: true },
+        ),
+        paymentMethod: varchar('payment_method', { length: 20 }),
+        notes: text('notes'),
+        createdBy: uuid('created_by')
+            .notNull()
+            .references(() => users.id),
+        createdAt: timestamp('created_at').defaultNow().notNull(),
+        updatedAt: timestamp('updated_at').defaultNow().notNull(),
+    },
+    (table) => ({
+        customerIdx: index('idx_invoices_customer_id').on(table.customerId),
+        statusIdx: index('idx_invoices_status').on(table.status),
+        dueDateIdx: index('idx_invoices_due_date').on(table.dueDate),
+        numberIdx: index('idx_invoices_invoice_number').on(table.invoiceNumber),
+        createdAtIdx: index('idx_invoices_created_at').on(table.createdAt),
+    }),
+);
+
+export const invoiceItems = appSchema.table('invoice_items', {
+    id: uuid('id').defaultRandom().primaryKey(),
+    invoiceId: uuid('invoice_id')
+        .notNull()
+        .references(() => invoices.id, { onDelete: 'cascade' }),
+    productId: uuid('product_id').references(() => products.id, { onDelete: 'set null' }),
+    description: text('description').notNull(),
+    quantity: integer('quantity').notNull(),
+    unitPrice: numeric('unit_price', { precision: 10, scale: 2 }).notNull(),
+    discount: numeric('discount', { precision: 10, scale: 2 }).default(sql`0.00`).notNull(),
+    totalPrice: numeric('total_price', { precision: 10, scale: 2 }).notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
+export const payments = appSchema.table(
+    'payments',
+    {
+        id: uuid('id').defaultRandom().primaryKey(),
+        paymentNumber: varchar('payment_number', { length: 20 }).notNull().unique(),
+        invoiceId: uuid('invoice_id')
+            .notNull()
+            .references(() => invoices.id, { onDelete: 'cascade' }),
+        amount: numeric('amount', { precision: 10, scale: 2 }).notNull(),
+        paymentMethod: varchar('payment_method', { length: 20 }).notNull(),
+        paymentReference: varchar('payment_reference', { length: 100 }),
+        paymentDate: timestamp('payment_date').defaultNow(),
+        status: varchar('status', { length: 20 }).default('completed').notNull(),
+        notes: text('notes'),
+        receivedBy: uuid('received_by')
+            .notNull()
+            .references(() => users.id),
+        createdAt: timestamp('created_at').defaultNow().notNull(),
+    },
+    (table) => ({
+        invoiceIdx: index('idx_payments_invoice_id').on(table.invoiceId),
+        methodIdx: index('idx_payments_payment_method').on(table.paymentMethod),
+        dateIdx: index('idx_payments_payment_date').on(table.paymentDate),
+        statusIdx: index('idx_payments_status').on(table.status),
+    }),
+);
+
+export const inventoryMovements = appSchema.table('inventory_movements', {
+    id: uuid('id').defaultRandom().primaryKey(),
+    productId: uuid('product_id')
+        .notNull()
+        .references(() => products.id, { onDelete: 'cascade' }),
+    movementType: varchar('movement_type', { length: 20 }).notNull(),
+    quantity: integer('quantity').notNull(),
+    referenceType: varchar('reference_type', { length: 50 }),
+    referenceId: uuid('reference_id'),
+    notes: text('notes'),
+    createdBy: uuid('created_by')
+        .notNull()
+        .references(() => users.id),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
+export const whatsappSessions = appSchema.table(
+    'whatsapp_sessions',
+    {
+        id: uuid('id').defaultRandom().primaryKey(),
+        customerId: uuid('customer_id').references(() => customers.id, { onDelete: 'cascade' }),
+        sessionId: varchar('session_id', { length: 100 }).notNull().unique(),
+        phoneNumber: varchar('phone_number', { length: 20 }).notNull(),
+        isActive: boolean('is_active').default(true),
+        lastActivity: timestamp('last_activity').defaultNow(),
+        createdAt: timestamp('created_at').defaultNow().notNull(),
+    },
+    (table) => ({
+        customerIdx: index('idx_whatsapp_sessions_customer_id').on(table.customerId),
+        phoneIdx: index('idx_whatsapp_sessions_phone_number').on(table.phoneNumber),
+    }),
+);
+
+export const whatsappMessages = appSchema.table(
+    'whatsapp_messages',
+    {
+        id: uuid('id').defaultRandom().primaryKey(),
+        sessionId: uuid('session_id')
+            .notNull()
+            .references(() => whatsappSessions.id, { onDelete: 'cascade' }),
+        messageId: varchar('message_id', { length: 100 }),
+        direction: varchar('direction', { length: 20 }).notNull(),
+        messageContent: text('message_content').notNull(),
+        mediaType: varchar('media_type', { length: 20 }),
+        mediaUrl: text('media_url'),
+        status: varchar('status', { length: 20 }).default('delivered'),
+        timestamp: timestamp('timestamp').defaultNow(),
+        createdAt: timestamp('created_at').defaultNow().notNull(),
+    },
+    (table) => ({
+        sessionIdx: index('idx_whatsapp_messages_session_id').on(table.sessionId),
+        directionIdx: index('idx_whatsapp_messages_direction').on(table.direction),
+        timestampIdx: index('idx_whatsapp_messages_timestamp').on(table.timestamp),
+    }),
+);
+
+export const aiConversations = appSchema.table(
+    'ai_conversations',
+    {
+        id: uuid('id').defaultRandom().primaryKey(),
+        customerId: uuid('customer_id').references(() => customers.id, { onDelete: 'cascade' }),
+        sessionId: varchar('session_id', { length: 100 }).notNull(),
+        messageContent: text('message_content').notNull(),
+        responseContent: text('response_content').notNull(),
+        intent: varchar('intent', { length: 50 }),
+        confidenceScore: numeric('confidence_score', { precision: 5, scale: 4 }),
+        sentimentScore: numeric('sentiment_score', { precision: 5, scale: 4 }),
+        sentimentLabel: varchar('sentiment_label', { length: 20 }),
+        createdAt: timestamp('created_at').defaultNow().notNull(),
+    },
+    (table) => ({
+        customerIdx: index('idx_ai_conversations_customer_id').on(table.customerId),
+        intentIdx: index('idx_ai_conversations_intent').on(table.intent),
+        createdAtIdx: index('idx_ai_conversations_created_at').on(table.createdAt),
+    }),
+);
+
+export const aiIntents = appSchema.table('ai_intents', {
+    id: uuid('id').defaultRandom().primaryKey(),
+    intentName: varchar('intent_name', { length: 50 }).notNull().unique(),
+    description: text('description'),
+    keywords: text('keywords').array(),
+    responseTemplate: text('response_template'),
+    actionType: varchar('action_type', { length: 50 }),
+    isActive: boolean('is_active').default(true),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+export const customerSentiments = appSchema.table(
+    'customer_sentiments',
+    {
+        id: uuid('id').defaultRandom().primaryKey(),
+        customerId: uuid('customer_id')
+            .notNull()
+            .references(() => customers.id, { onDelete: 'cascade' }),
+        ticketId: uuid('ticket_id').references(() => tickets.id, { onDelete: 'set null' }),
+        messageId: uuid('message_id').references(() => whatsappMessages.id, { onDelete: 'set null' }),
+        sentimentScore: numeric('sentiment_score', { precision: 5, scale: 4 }),
+        sentimentLabel: varchar('sentiment_label', { length: 20 }),
+        confidence: numeric('confidence', { precision: 5, scale: 4 }),
+        analyzedAt: timestamp('analyzed_at').defaultNow().notNull(),
+    },
+    (table) => ({
+        customerIdx: index('idx_customer_sentiments_customer_id').on(table.customerId),
+        labelIdx: index('idx_customer_sentiments_sentiment_label').on(table.sentimentLabel),
+    }),
+);
+
+export const aiRecommendations = appSchema.table('ai_recommendations', {
+    id: uuid('id').defaultRandom().primaryKey(),
+    customerId: uuid('customer_id')
+        .notNull()
+        .references(() => customers.id, { onDelete: 'cascade' }),
+    productId: uuid('product_id')
+        .notNull()
+        .references(() => products.id, { onDelete: 'cascade' }),
+    recommendationType: varchar('recommendation_type', { length: 50 }).notNull(),
+    confidenceScore: numeric('confidence_score', { precision: 5, scale: 4 }),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    clicked: boolean('clicked').default(false),
+    purchased: boolean('purchased').default(false),
+});
+
+export const aiInsights = appSchema.table('ai_insights', {
+    id: uuid('id').defaultRandom().primaryKey(),
+    insightType: varchar('insight_type', { length: 50 }).notNull(),
+    title: varchar('title', { length: 200 }).notNull(),
+    description: text('description').notNull(),
+    data: jsonb('data'),
+    confidenceScore: numeric('confidence_score', { precision: 5, scale: 4 }),
+    isActionable: boolean('is_actionable').default(true),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    acknowledged: boolean('acknowledged').default(false),
+    acknowledgedBy: uuid('acknowledged_by').references(() => users.id),
+    acknowledgedAt: timestamp('acknowledged_at'),
+});
+
+export const customerInteractions = appSchema.table('customer_interactions', {
+    id: uuid('id').defaultRandom().primaryKey(),
+    customerId: uuid('customer_id')
+        .notNull()
+        .references(() => customers.id, { onDelete: 'cascade' }),
+    interactionType: varchar('interaction_type', { length: 50 }).notNull(),
+    interactionId: uuid('interaction_id'),
+    description: text('description'),
+    direction: varchar('direction', { length: 20 }),
+    createdBy: uuid('created_by').references(() => users.id),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
+export const customerFeedback = appSchema.table('customer_feedback', {
+    id: uuid('id').defaultRandom().primaryKey(),
+    customerId: uuid('customer_id')
+        .notNull()
+        .references(() => customers.id, { onDelete: 'cascade' }),
+    ticketId: uuid('ticket_id').references(() => tickets.id, { onDelete: 'set null' }),
+    invoiceId: uuid('invoice_id').references(() => invoices.id, { onDelete: 'set null' }),
+    rating: integer('rating'),
+    feedbackText: text('feedback_text'),
+    feedbackSource: varchar('feedback_source', { length: 50 }).default('whatsapp').notNull(),
+    isPublic: boolean('is_public').default(false),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
+export const customerPreferences = appSchema.table('customer_preferences', {
+    id: uuid('id').defaultRandom().primaryKey(),
+    customerId: uuid('customer_id')
+        .notNull()
+        .unique()
+        .references(() => customers.id, { onDelete: 'cascade' }),
+    preferredContactMethod: varchar('preferred_contact_method', { length: 20 })
+        .default('whatsapp')
+        .notNull(),
+    notificationPreferences: jsonb('notification_preferences').default(sql`'{}'::jsonb`).notNull(),
+    marketingConsent: boolean('marketing_consent').default(true),
+    languagePreference: varchar('language_preference', { length: 10 }).default('ms').notNull(),
+    notes: text('notes'),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+export const analyticsEvents = appSchema.table('analytics_events', {
+    id: uuid('id').defaultRandom().primaryKey(),
+    eventType: varchar('event_type', { length: 50 }).notNull(),
+    eventData: jsonb('event_data'),
+    customerId: uuid('customer_id').references(() => customers.id, { onDelete: 'set null' }),
+    userId: uuid('user_id').references(() => users.id, { onDelete: 'set null' }),
+    sessionId: varchar('session_id', { length: 100 }),
+    ipAddress: inet('ip_address'),
+    userAgent: text('user_agent'),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
+export const reports = appSchema.table('reports', {
+    id: uuid('id').defaultRandom().primaryKey(),
+    name: varchar('name', { length: 100 }).notNull(),
+    reportType: varchar('report_type', { length: 50 }).notNull(),
+    parameters: jsonb('parameters').default(sql`'{}'::jsonb`).notNull(),
+    generatedBy: uuid('generated_by')
+        .notNull()
+        .references(() => users.id),
+    fileUrl: text('file_url'),
+    status: varchar('status', { length: 20 }).default('pending').notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    completedAt: timestamp('completed_at'),
+});
+
+export const auditLogs = appSchema.table(
+    'audit_logs',
+    {
+        id: uuid('id').defaultRandom().primaryKey(),
+        userId: uuid('user_id').references(() => users.id, { onDelete: 'set null' }),
+        action: varchar('action', { length: 100 }).notNull(),
+        tableName: varchar('table_name', { length: 50 }),
+        recordId: uuid('record_id'),
+        oldValues: jsonb('old_values'),
+        newValues: jsonb('new_values'),
+        ipAddress: inet('ip_address'),
+        userAgent: text('user_agent'),
+        createdAt: timestamp('created_at').defaultNow().notNull(),
+    },
+    (table) => ({
+        userIdx: index('idx_audit_logs_user_id').on(table.userId),
+        actionIdx: index('idx_audit_logs_action').on(table.action),
+        tableIdx: index('idx_audit_logs_table_name').on(table.tableName),
+        createdIdx: index('idx_audit_logs_created_at').on(table.createdAt),
+    }),
+);
+
+export const systemSettings = appSchema.table('system_settings', {
+    id: uuid('id').defaultRandom().primaryKey(),
+    settingKey: varchar('setting_key', { length: 100 }).notNull().unique(),
+    settingValue: text('setting_value'),
+    description: text('description'),
+    isEncrypted: boolean('is_encrypted').default(false),
+    updatedBy: uuid('updated_by').references(() => users.id),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+export const companySettings = appSchema.table('company_settings', {
+    id: uuid('id').defaultRandom().primaryKey(),
+    companyName: varchar('company_name', { length: 100 }).notNull(),
+    address: text('address'),
+    phone: varchar('phone', { length: 20 }),
+    email: varchar('email', { length: 100 }),
+    website: varchar('website', { length: 100 }),
+    registrationNumber: varchar('registration_number', { length: 50 }),
+    taxNumber: varchar('tax_number', { length: 50 }),
+    logoUrl: text('logo_url'),
+    currency: varchar('currency', { length: 3 }).default('MYR').notNull(),
+    taxRate: numeric('tax_rate', { precision: 5, scale: 2 }).default(sql`6.00`).notNull(),
+    invoicePrefix: varchar('invoice_prefix', { length: 10 }).default('INV').notNull(),
+    quotationPrefix: varchar('quotation_prefix', { length: 10 }).default('QTN').notNull(),
+    ticketPrefix: varchar('ticket_prefix', { length: 10 }).default('TKT').notNull(),
+    updatedBy: uuid('updated_by').references(() => users.id),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+export const userSessions = appSchema.table(
+    'user_sessions',
+    {
+        id: uuid('id').defaultRandom().primaryKey(),
+        userId: uuid('user_id')
+            .notNull()
+            .references(() => users.id, { onDelete: 'cascade' }),
+        sessionToken: varchar('session_token', { length: 255 }).notNull().unique(),
+        expiresAt: timestamp('expires_at').notNull(),
+        ipAddress: inet('ip_address'),
+        userAgent: text('user_agent'),
+        isActive: boolean('is_active').default(true),
+        createdAt: timestamp('created_at').defaultNow().notNull(),
+        lastAccessed: timestamp('last_accessed').defaultNow().notNull(),
+    },
+    (table) => ({
+        userIdx: index('idx_user_sessions_user_id').on(table.userId),
+    }),
+);
+
+export const backupLogs = appSchema.table('backup_logs', {
+    id: uuid('id').defaultRandom().primaryKey(),
+    filename: varchar('filename', { length: 255 }).notNull(),
+    fileSize: bigint('file_size', { mode: 'number' }),
+    backupType: varchar('backup_type', { length: 20 }).notNull(),
+    status: varchar('status', { length: 20 }).notNull(),
+    startedAt: timestamp('started_at').defaultNow().notNull(),
+    completedAt: timestamp('completed_at'),
+    notes: text('notes'),
+});
+
+export const apiKeys = appSchema.table('api_keys', {
+    id: uuid('id').defaultRandom().primaryKey(),
+    name: varchar('name', { length: 100 }).notNull(),
+    keyHash: varchar('key_hash', { length: 255 }).notNull().unique(),
+    permissions: jsonb('permissions').default(sql`'[]'::jsonb`).notNull(),
+    lastUsedAt: timestamp('last_used_at'),
+    expiresAt: timestamp('expires_at'),
+    isActive: boolean('is_active').default(true),
+    createdBy: uuid('created_by')
+        .notNull()
+        .references(() => users.id),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});

--- a/db/schema/index.ts
+++ b/db/schema/index.ts
@@ -1,0 +1,2 @@
+export * from './auth';
+export * from './app';

--- a/drizzle/0001_app_domain.sql
+++ b/drizzle/0001_app_domain.sql
@@ -1,0 +1,622 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE SCHEMA IF NOT EXISTS "app";
+
+CREATE TABLE "app"."users" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "username" varchar(50) NOT NULL UNIQUE,
+    "email" varchar(100) NOT NULL UNIQUE,
+    "password_hash" varchar(255) NOT NULL,
+    "role" varchar(20) NOT NULL CHECK ("role" IN ('admin', 'staff', 'technician')),
+    "full_name" varchar(100) NOT NULL,
+    "phone" varchar(20),
+    "is_active" boolean DEFAULT true,
+    "last_login" timestamp,
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."customers" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "name" varchar(100) NOT NULL,
+    "phone" varchar(20) NOT NULL UNIQUE,
+    "email" varchar(100),
+    "address" text,
+    "company_name" varchar(100),
+    "customer_type" varchar(20) DEFAULT 'individual' CHECK ("customer_type" IN ('individual', 'business')),
+    "notes" text,
+    "created_by" uuid REFERENCES "app"."users"("id"),
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."products" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "name" varchar(100) NOT NULL,
+    "description" text,
+    "category" varchar(50) NOT NULL,
+    "sku" varchar(50) UNIQUE,
+    "barcode" varchar(50),
+    "price" numeric(10, 2) NOT NULL,
+    "cost" numeric(10, 2) NOT NULL,
+    "stock_quantity" integer DEFAULT 0 NOT NULL,
+    "reorder_level" integer DEFAULT 10 NOT NULL,
+    "unit_of_measure" varchar(20) DEFAULT 'unit' NOT NULL,
+    "is_active" boolean DEFAULT true,
+    "created_by" uuid REFERENCES "app"."users"("id"),
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."tickets" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "ticket_number" varchar(20) NOT NULL UNIQUE,
+    "customer_id" uuid NOT NULL REFERENCES "app"."customers"("id") ON DELETE CASCADE,
+    "device_type" varchar(50) NOT NULL,
+    "device_model" varchar(100) NOT NULL,
+    "serial_number" varchar(50),
+    "problem_description" text NOT NULL,
+    "status" varchar(20) DEFAULT 'pending' CHECK ("status" IN ('pending', 'diagnosing', 'approved', 'in_progress', 'completed', 'ready_for_pickup', 'picked_up', 'cancelled')),
+    "priority" varchar(20) DEFAULT 'normal' CHECK ("priority" IN ('low', 'normal', 'high', 'urgent')),
+    "estimated_cost" numeric(10, 2),
+    "actual_cost" numeric(10, 2),
+    "estimated_completion_date" date,
+    "technician_notes" text,
+    "assigned_to" uuid REFERENCES "app"."users"("id"),
+    "created_by" uuid REFERENCES "app"."users"("id"),
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."ticket_updates" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "ticket_id" uuid NOT NULL REFERENCES "app"."tickets"("id") ON DELETE CASCADE,
+    "update_type" varchar(50) NOT NULL,
+    "description" text,
+    "image_url" text,
+    "updated_by" uuid NOT NULL REFERENCES "app"."users"("id"),
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."quotations" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "quotation_number" varchar(20) NOT NULL UNIQUE,
+    "customer_id" uuid NOT NULL REFERENCES "app"."customers"("id") ON DELETE CASCADE,
+    "ticket_id" uuid REFERENCES "app"."tickets"("id") ON DELETE SET NULL,
+    "valid_until" date NOT NULL,
+    "status" varchar(20) DEFAULT 'draft' CHECK ("status" IN ('draft', 'sent', 'accepted', 'rejected', 'expired', 'converted')),
+    "subtotal" numeric(10, 2) NOT NULL,
+    "tax_rate" numeric(5, 2) DEFAULT 6.00 NOT NULL,
+    "tax_amount" numeric(10, 2) NOT NULL,
+    "total" numeric(10, 2) NOT NULL,
+    "notes" text,
+    "terms" text,
+    "created_by" uuid NOT NULL REFERENCES "app"."users"("id"),
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."quotation_items" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "quotation_id" uuid NOT NULL REFERENCES "app"."quotations"("id") ON DELETE CASCADE,
+    "product_id" uuid REFERENCES "app"."products"("id") ON DELETE SET NULL,
+    "description" text NOT NULL,
+    "quantity" integer NOT NULL,
+    "unit_price" numeric(10, 2) NOT NULL,
+    "discount" numeric(10, 2) DEFAULT 0.00 NOT NULL,
+    "total_price" numeric(10, 2) NOT NULL,
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."invoices" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "invoice_number" varchar(20) NOT NULL UNIQUE,
+    "customer_id" uuid NOT NULL REFERENCES "app"."customers"("id") ON DELETE CASCADE,
+    "ticket_id" uuid REFERENCES "app"."tickets"("id") ON DELETE SET NULL,
+    "quotation_id" uuid REFERENCES "app"."quotations"("id") ON DELETE SET NULL,
+    "invoice_date" date DEFAULT CURRENT_DATE NOT NULL,
+    "due_date" date NOT NULL,
+    "status" varchar(20) DEFAULT 'draft' CHECK ("status" IN ('draft', 'sent', 'paid', 'partial', 'overdue', 'cancelled')),
+    "subtotal" numeric(10, 2) NOT NULL,
+    "tax_rate" numeric(5, 2) DEFAULT 6.00 NOT NULL,
+    "tax_amount" numeric(10, 2) NOT NULL,
+    "total" numeric(10, 2) NOT NULL,
+    "paid_amount" numeric(10, 2) DEFAULT 0.00 NOT NULL,
+    "balance" numeric(10, 2) GENERATED ALWAYS AS ("total" - "paid_amount") STORED,
+    "payment_method" varchar(20),
+    "notes" text,
+    "created_by" uuid NOT NULL REFERENCES "app"."users"("id"),
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."invoice_items" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "invoice_id" uuid NOT NULL REFERENCES "app"."invoices"("id") ON DELETE CASCADE,
+    "product_id" uuid REFERENCES "app"."products"("id") ON DELETE SET NULL,
+    "description" text NOT NULL,
+    "quantity" integer NOT NULL,
+    "unit_price" numeric(10, 2) NOT NULL,
+    "discount" numeric(10, 2) DEFAULT 0.00 NOT NULL,
+    "total_price" numeric(10, 2) NOT NULL,
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."payments" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "payment_number" varchar(20) NOT NULL UNIQUE,
+    "invoice_id" uuid NOT NULL REFERENCES "app"."invoices"("id") ON DELETE CASCADE,
+    "amount" numeric(10, 2) NOT NULL,
+    "payment_method" varchar(20) NOT NULL CHECK ("payment_method" IN ('cash', 'card', 'bank_transfer', 'ewallet', 'cheque')),
+    "payment_reference" varchar(100),
+    "payment_date" timestamp DEFAULT CURRENT_TIMESTAMP,
+    "status" varchar(20) DEFAULT 'completed' CHECK ("status" IN ('pending', 'completed', 'failed', 'refunded')),
+    "notes" text,
+    "received_by" uuid NOT NULL REFERENCES "app"."users"("id"),
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."inventory_movements" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "product_id" uuid NOT NULL REFERENCES "app"."products"("id") ON DELETE CASCADE,
+    "movement_type" varchar(20) NOT NULL CHECK ("movement_type" IN ('in', 'out', 'adjustment', 'return')),
+    "quantity" integer NOT NULL,
+    "reference_type" varchar(50),
+    "reference_id" uuid,
+    "notes" text,
+    "created_by" uuid NOT NULL REFERENCES "app"."users"("id"),
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."whatsapp_sessions" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "customer_id" uuid REFERENCES "app"."customers"("id") ON DELETE CASCADE,
+    "session_id" varchar(100) NOT NULL UNIQUE,
+    "phone_number" varchar(20) NOT NULL,
+    "is_active" boolean DEFAULT true,
+    "last_activity" timestamp DEFAULT CURRENT_TIMESTAMP,
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."whatsapp_messages" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "session_id" uuid NOT NULL REFERENCES "app"."whatsapp_sessions"("id") ON DELETE CASCADE,
+    "message_id" varchar(100),
+    "direction" varchar(20) NOT NULL CHECK ("direction" IN ('inbound', 'outbound')),
+    "message_content" text NOT NULL,
+    "media_type" varchar(20),
+    "media_url" text,
+    "status" varchar(20) DEFAULT 'delivered',
+    "timestamp" timestamp DEFAULT CURRENT_TIMESTAMP,
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."ai_conversations" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "customer_id" uuid REFERENCES "app"."customers"("id") ON DELETE CASCADE,
+    "session_id" varchar(100) NOT NULL,
+    "message_content" text NOT NULL,
+    "response_content" text NOT NULL,
+    "intent" varchar(50),
+    "confidence_score" numeric(5, 4),
+    "sentiment_score" numeric(5, 4),
+    "sentiment_label" varchar(20),
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."ai_intents" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "intent_name" varchar(50) NOT NULL UNIQUE,
+    "description" text,
+    "keywords" text[],
+    "response_template" text,
+    "action_type" varchar(50),
+    "is_active" boolean DEFAULT true,
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."customer_sentiments" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "customer_id" uuid NOT NULL REFERENCES "app"."customers"("id") ON DELETE CASCADE,
+    "ticket_id" uuid REFERENCES "app"."tickets"("id") ON DELETE SET NULL,
+    "message_id" uuid REFERENCES "app"."whatsapp_messages"("id") ON DELETE SET NULL,
+    "sentiment_score" numeric(5, 4),
+    "sentiment_label" varchar(20) CHECK ("sentiment_label" IN ('positive', 'neutral', 'negative')),
+    "confidence" numeric(5, 4),
+    "analyzed_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."ai_recommendations" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "customer_id" uuid NOT NULL REFERENCES "app"."customers"("id") ON DELETE CASCADE,
+    "product_id" uuid NOT NULL REFERENCES "app"."products"("id") ON DELETE CASCADE,
+    "recommendation_type" varchar(50) NOT NULL CHECK ("recommendation_type" IN ('similar', 'complementary', 'frequently_bought_together')),
+    "confidence_score" numeric(5, 4),
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "clicked" boolean DEFAULT false,
+    "purchased" boolean DEFAULT false
+);
+
+CREATE TABLE "app"."ai_insights" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "insight_type" varchar(50) NOT NULL CHECK ("insight_type" IN ('customer_behavior', 'sales_trend', 'inventory_prediction', 'sentiment_analysis')),
+    "title" varchar(200) NOT NULL,
+    "description" text NOT NULL,
+    "data" jsonb,
+    "confidence_score" numeric(5, 4),
+    "is_actionable" boolean DEFAULT true,
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "acknowledged" boolean DEFAULT false,
+    "acknowledged_by" uuid REFERENCES "app"."users"("id"),
+    "acknowledged_at" timestamp
+);
+
+CREATE TABLE "app"."customer_interactions" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "customer_id" uuid NOT NULL REFERENCES "app"."customers"("id") ON DELETE CASCADE,
+    "interaction_type" varchar(50) NOT NULL CHECK ("interaction_type" IN ('whatsapp', 'call', 'email', 'visit', 'ticket', 'purchase')),
+    "interaction_id" uuid,
+    "description" text,
+    "direction" varchar(20) CHECK ("direction" IN ('inbound', 'outbound')),
+    "created_by" uuid REFERENCES "app"."users"("id"),
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."customer_feedback" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "customer_id" uuid NOT NULL REFERENCES "app"."customers"("id") ON DELETE CASCADE,
+    "ticket_id" uuid REFERENCES "app"."tickets"("id") ON DELETE SET NULL,
+    "invoice_id" uuid REFERENCES "app"."invoices"("id") ON DELETE SET NULL,
+    "rating" integer CHECK ("rating" >= 1 AND "rating" <= 5),
+    "feedback_text" text,
+    "feedback_source" varchar(50) DEFAULT 'whatsapp',
+    "is_public" boolean DEFAULT false,
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."customer_preferences" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "customer_id" uuid NOT NULL UNIQUE REFERENCES "app"."customers"("id") ON DELETE CASCADE,
+    "preferred_contact_method" varchar(20) DEFAULT 'whatsapp' NOT NULL,
+    "notification_preferences" jsonb DEFAULT '{}'::jsonb NOT NULL,
+    "marketing_consent" boolean DEFAULT true,
+    "language_preference" varchar(10) DEFAULT 'ms' NOT NULL,
+    "notes" text,
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."analytics_events" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "event_type" varchar(50) NOT NULL,
+    "event_data" jsonb,
+    "customer_id" uuid REFERENCES "app"."customers"("id") ON DELETE SET NULL,
+    "user_id" uuid REFERENCES "app"."users"("id") ON DELETE SET NULL,
+    "session_id" varchar(100),
+    "ip_address" inet,
+    "user_agent" text,
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."reports" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "name" varchar(100) NOT NULL,
+    "report_type" varchar(50) NOT NULL,
+    "parameters" jsonb DEFAULT '{}'::jsonb NOT NULL,
+    "generated_by" uuid NOT NULL REFERENCES "app"."users"("id"),
+    "file_url" text,
+    "status" varchar(20) DEFAULT 'pending' CHECK ("status" IN ('pending', 'generating', 'completed', 'failed')),
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "completed_at" timestamp
+);
+
+CREATE TABLE "app"."audit_logs" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "user_id" uuid REFERENCES "app"."users"("id") ON DELETE SET NULL,
+    "action" varchar(100) NOT NULL,
+    "table_name" varchar(50),
+    "record_id" uuid,
+    "old_values" jsonb,
+    "new_values" jsonb,
+    "ip_address" inet,
+    "user_agent" text,
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."system_settings" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "setting_key" varchar(100) NOT NULL UNIQUE,
+    "setting_value" text,
+    "description" text,
+    "is_encrypted" boolean DEFAULT false,
+    "updated_by" uuid REFERENCES "app"."users"("id"),
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."company_settings" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "company_name" varchar(100) NOT NULL,
+    "address" text,
+    "phone" varchar(20),
+    "email" varchar(100),
+    "website" varchar(100),
+    "registration_number" varchar(50),
+    "tax_number" varchar(50),
+    "logo_url" text,
+    "currency" varchar(3) DEFAULT 'MYR' NOT NULL,
+    "tax_rate" numeric(5, 2) DEFAULT 6.00 NOT NULL,
+    "invoice_prefix" varchar(10) DEFAULT 'INV' NOT NULL,
+    "quotation_prefix" varchar(10) DEFAULT 'QTN' NOT NULL,
+    "ticket_prefix" varchar(10) DEFAULT 'TKT' NOT NULL,
+    "updated_by" uuid REFERENCES "app"."users"("id"),
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."user_sessions" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "user_id" uuid NOT NULL REFERENCES "app"."users"("id") ON DELETE CASCADE,
+    "session_token" varchar(255) NOT NULL UNIQUE,
+    "expires_at" timestamp NOT NULL,
+    "ip_address" inet,
+    "user_agent" text,
+    "is_active" boolean DEFAULT true,
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "last_accessed" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "app"."backup_logs" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "filename" varchar(255) NOT NULL,
+    "file_size" bigint,
+    "backup_type" varchar(20) NOT NULL CHECK ("backup_type" IN ('full', 'incremental')),
+    "status" varchar(20) NOT NULL CHECK ("status" IN ('started', 'completed', 'failed')),
+    "started_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "completed_at" timestamp,
+    "notes" text
+);
+
+CREATE TABLE "app"."api_keys" (
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "name" varchar(100) NOT NULL,
+    "key_hash" varchar(255) NOT NULL UNIQUE,
+    "permissions" jsonb DEFAULT '[]'::jsonb NOT NULL,
+    "last_used_at" timestamp,
+    "expires_at" timestamp,
+    "is_active" boolean DEFAULT true,
+    "created_by" uuid NOT NULL REFERENCES "app"."users"("id"),
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE INDEX "idx_customers_phone" ON "app"."customers" ("phone");
+CREATE INDEX "idx_customers_name" ON "app"."customers" ("name");
+CREATE INDEX "idx_customers_email" ON "app"."customers" ("email");
+CREATE INDEX "idx_customers_created_at" ON "app"."customers" ("created_at");
+
+CREATE INDEX "idx_tickets_customer_id" ON "app"."tickets" ("customer_id");
+CREATE INDEX "idx_tickets_status" ON "app"."tickets" ("status");
+CREATE INDEX "idx_tickets_assigned_to" ON "app"."tickets" ("assigned_to");
+CREATE INDEX "idx_tickets_created_at" ON "app"."tickets" ("created_at");
+CREATE INDEX "idx_tickets_ticket_number" ON "app"."tickets" ("ticket_number");
+
+CREATE INDEX "idx_products_sku" ON "app"."products" ("sku");
+CREATE INDEX "idx_products_category" ON "app"."products" ("category");
+CREATE INDEX "idx_products_name" ON "app"."products" ("name");
+CREATE INDEX "idx_products_stock_quantity" ON "app"."products" ("stock_quantity");
+
+CREATE INDEX "idx_quotations_customer_id" ON "app"."quotations" ("customer_id");
+CREATE INDEX "idx_quotations_status" ON "app"."quotations" ("status");
+CREATE INDEX "idx_quotations_valid_until" ON "app"."quotations" ("valid_until");
+CREATE INDEX "idx_quotations_quotation_number" ON "app"."quotations" ("quotation_number");
+
+CREATE INDEX "idx_invoices_customer_id" ON "app"."invoices" ("customer_id");
+CREATE INDEX "idx_invoices_status" ON "app"."invoices" ("status");
+CREATE INDEX "idx_invoices_due_date" ON "app"."invoices" ("due_date");
+CREATE INDEX "idx_invoices_invoice_number" ON "app"."invoices" ("invoice_number");
+CREATE INDEX "idx_invoices_created_at" ON "app"."invoices" ("created_at");
+
+CREATE INDEX "idx_payments_invoice_id" ON "app"."payments" ("invoice_id");
+CREATE INDEX "idx_payments_payment_method" ON "app"."payments" ("payment_method");
+CREATE INDEX "idx_payments_payment_date" ON "app"."payments" ("payment_date");
+CREATE INDEX "idx_payments_status" ON "app"."payments" ("status");
+
+CREATE INDEX "idx_ai_conversations_customer_id" ON "app"."ai_conversations" ("customer_id");
+CREATE INDEX "idx_ai_conversations_intent" ON "app"."ai_conversations" ("intent");
+CREATE INDEX "idx_ai_conversations_created_at" ON "app"."ai_conversations" ("created_at");
+CREATE INDEX "idx_customer_sentiments_customer_id" ON "app"."customer_sentiments" ("customer_id");
+CREATE INDEX "idx_customer_sentiments_sentiment_label" ON "app"."customer_sentiments" ("sentiment_label");
+
+CREATE INDEX "idx_whatsapp_sessions_customer_id" ON "app"."whatsapp_sessions" ("customer_id");
+CREATE INDEX "idx_whatsapp_sessions_phone_number" ON "app"."whatsapp_sessions" ("phone_number");
+CREATE INDEX "idx_whatsapp_messages_session_id" ON "app"."whatsapp_messages" ("session_id");
+CREATE INDEX "idx_whatsapp_messages_direction" ON "app"."whatsapp_messages" ("direction");
+CREATE INDEX "idx_whatsapp_messages_timestamp" ON "app"."whatsapp_messages" ("timestamp");
+
+CREATE INDEX "idx_audit_logs_user_id" ON "app"."audit_logs" ("user_id");
+CREATE INDEX "idx_audit_logs_action" ON "app"."audit_logs" ("action");
+CREATE INDEX "idx_audit_logs_table_name" ON "app"."audit_logs" ("table_name");
+CREATE INDEX "idx_audit_logs_created_at" ON "app"."audit_logs" ("created_at");
+
+CREATE INDEX "idx_users_username" ON "app"."users" ("username");
+CREATE INDEX "idx_users_email" ON "app"."users" ("email");
+CREATE INDEX "idx_user_sessions_user_id" ON "app"."user_sessions" ("user_id");
+
+ALTER TABLE "app"."users" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "app"."customers" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "app"."tickets" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "app"."quotations" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "app"."invoices" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "app"."payments" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "app"."ai_conversations" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "app"."audit_logs" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users_isolation_policy" ON "app"."users"
+    FOR ALL
+    USING ("id" = auth.uid() OR "role" = 'admin')
+    WITH CHECK ("id" = auth.uid() OR "role" = 'admin');
+
+CREATE POLICY "customer_access_policy" ON "app"."customers"
+    FOR SELECT
+    USING (true);
+
+CREATE POLICY "customer_insert_policy" ON "app"."customers"
+    FOR INSERT
+    WITH CHECK (true);
+
+CREATE POLICY "customer_update_policy" ON "app"."customers"
+    FOR UPDATE
+    USING (
+        "created_by" = auth.uid()
+        OR EXISTS (
+            SELECT 1 FROM "app"."users" u WHERE u."id" = auth.uid() AND u."role" = 'admin'
+        )
+    );
+
+CREATE POLICY "customer_delete_policy" ON "app"."customers"
+    FOR DELETE
+    USING (
+        "created_by" = auth.uid()
+        OR EXISTS (
+            SELECT 1 FROM "app"."users" u WHERE u."id" = auth.uid() AND u."role" = 'admin'
+        )
+    );
+
+CREATE POLICY "ticket_select_policy" ON "app"."tickets"
+    FOR SELECT
+    USING (
+        "assigned_to" = auth.uid()
+        OR "created_by" = auth.uid()
+        OR EXISTS (
+            SELECT 1 FROM "app"."users" u WHERE u."id" = auth.uid() AND u."role" IN ('admin', 'staff')
+        )
+    );
+
+CREATE POLICY "ticket_insert_policy" ON "app"."tickets"
+    FOR INSERT
+    WITH CHECK (true);
+
+CREATE POLICY "ticket_update_policy" ON "app"."tickets"
+    FOR UPDATE
+    USING (
+        "assigned_to" = auth.uid()
+        OR "created_by" = auth.uid()
+        OR EXISTS (
+            SELECT 1 FROM "app"."users" u WHERE u."id" = auth.uid() AND u."role" = 'admin'
+        )
+    );
+
+CREATE POLICY "ticket_delete_policy" ON "app"."tickets"
+    FOR DELETE
+    USING (
+        EXISTS (
+            SELECT 1 FROM "app"."users" u WHERE u."id" = auth.uid() AND u."role" = 'admin'
+        )
+    );
+
+CREATE POLICY "quotation_select_policy" ON "app"."quotations"
+    FOR SELECT
+    USING (
+        "created_by" = auth.uid()
+        OR EXISTS (
+            SELECT 1 FROM "app"."users" u WHERE u."id" = auth.uid() AND u."role" IN ('admin', 'staff')
+        )
+    );
+
+CREATE POLICY "quotation_insert_policy" ON "app"."quotations"
+    FOR INSERT
+    WITH CHECK (true);
+
+CREATE POLICY "quotation_update_policy" ON "app"."quotations"
+    FOR UPDATE
+    USING (
+        "created_by" = auth.uid()
+        OR EXISTS (
+            SELECT 1 FROM "app"."users" u WHERE u."id" = auth.uid() AND u."role" = 'admin'
+        )
+    );
+
+CREATE POLICY "quotation_delete_policy" ON "app"."quotations"
+    FOR DELETE
+    USING (
+        EXISTS (
+            SELECT 1 FROM "app"."users" u WHERE u."id" = auth.uid() AND u."role" = 'admin'
+        )
+    );
+
+CREATE POLICY "invoice_select_policy" ON "app"."invoices"
+    FOR SELECT
+    USING (
+        "created_by" = auth.uid()
+        OR EXISTS (
+            SELECT 1 FROM "app"."users" u WHERE u."id" = auth.uid() AND u."role" IN ('admin', 'staff')
+        )
+    );
+
+CREATE POLICY "invoice_insert_policy" ON "app"."invoices"
+    FOR INSERT
+    WITH CHECK (true);
+
+CREATE POLICY "invoice_update_policy" ON "app"."invoices"
+    FOR UPDATE
+    USING (
+        "created_by" = auth.uid()
+        OR EXISTS (
+            SELECT 1 FROM "app"."users" u WHERE u."id" = auth.uid() AND u."role" = 'admin'
+        )
+    );
+
+CREATE POLICY "invoice_delete_policy" ON "app"."invoices"
+    FOR DELETE
+    USING (
+        EXISTS (
+            SELECT 1 FROM "app"."users" u WHERE u."id" = auth.uid() AND u."role" = 'admin'
+        )
+    );
+
+CREATE POLICY "payment_select_policy" ON "app"."payments"
+    FOR SELECT
+    USING (
+        "received_by" = auth.uid()
+        OR EXISTS (
+            SELECT 1 FROM "app"."users" u WHERE u."id" = auth.uid() AND u."role" IN ('admin', 'staff')
+        )
+    );
+
+CREATE POLICY "payment_insert_policy" ON "app"."payments"
+    FOR INSERT
+    WITH CHECK (true);
+
+CREATE POLICY "payment_update_policy" ON "app"."payments"
+    FOR UPDATE
+    USING (
+        "received_by" = auth.uid()
+        OR EXISTS (
+            SELECT 1 FROM "app"."users" u WHERE u."id" = auth.uid() AND u."role" = 'admin'
+        )
+    );
+
+CREATE POLICY "ai_conversation_select_policy" ON "app"."ai_conversations"
+    FOR SELECT
+    USING (
+        EXISTS (
+            SELECT 1 FROM "app"."users" u WHERE u."id" = auth.uid() AND u."role" IN ('admin', 'staff')
+        )
+    );
+
+CREATE POLICY "ai_conversation_insert_policy" ON "app"."ai_conversations"
+    FOR INSERT
+    WITH CHECK (true);
+
+CREATE POLICY "audit_log_select_policy" ON "app"."audit_logs"
+    FOR SELECT
+    USING (
+        EXISTS (
+            SELECT 1 FROM "app"."users" u WHERE u."id" = auth.uid() AND u."role" = 'admin'
+        )
+    );
+
+CREATE POLICY "audit_log_insert_policy" ON "app"."audit_logs"
+    FOR INSERT
+    WITH CHECK (true);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1756202589329,
       "tag": "0000_overjoyed_morlun",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1759005044560,
+      "tag": "0001_app_domain",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add Drizzle ORM models for the app schema covering CRM, POS, AI, and system tables
- introduce SQL migration to create the app schema tables, indexes, and RLS policies per the technical requirements
- export the new schema objects for application usage and record the migration in the journal

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8489bf644832bb84e824c772c0511