### PR TITLE
Add validated environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Copy this file to .env and modify as needed
 
 # Database Configuration
-DATABASE_URL=postgresql://postgres:postgres@localhost:5433/postgres
+DATABASE_URL=postgresql://postgres:postgres@postgres:5432/postgres
 POSTGRES_DB=postgres
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
@@ -11,3 +11,9 @@ POSTGRES_PASSWORD=postgres
 BETTER_AUTH_SECRET=your_secret_key_here
 BETTER_AUTH_URL=http://localhost:3000
 NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:3000
+
+# WhatsApp Gateway
+WA_OUTBOUND_URL=http://wa:3000
+
+# File Storage
+FILES_DIR=./files

--- a/db/index.ts
+++ b/db/index.ts
@@ -1,4 +1,4 @@
-import 'dotenv/config';
 import { drizzle } from 'drizzle-orm/node-postgres';
+import env from '../env.mjs';
 
-export const db = drizzle(process.env.DATABASE_URL!);
+export const db = drizzle(env.DATABASE_URL);

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -56,7 +56,7 @@ services:
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:3000}
       NEXT_PUBLIC_BETTER_AUTH_URL: ${NEXT_PUBLIC_BETTER_AUTH_URL:-http://localhost:3000}
       REDIS_URL: redis://redis:6379
-      WA_GATEWAY_URL: http://wa:3000
+      WA_OUTBOUND_URL: ${WA_OUTBOUND_URL:-http://wa:3000}
     ports:
       - "3000:3000"
     depends_on:

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,11 +1,11 @@
-import 'dotenv/config';
 import { defineConfig } from 'drizzle-kit';
+import env from './env.mjs';
 
 export default defineConfig({
     out: './drizzle',
     schema: './db/schema/*',
     dialect: 'postgresql',
     dbCredentials: {
-        url: process.env.DATABASE_URL!,
+        url: env.DATABASE_URL,
     },
 });

--- a/env.mjs
+++ b/env.mjs
@@ -1,0 +1,29 @@
+import { config as loadEnv } from 'dotenv';
+import path from 'node:path';
+import { z } from 'zod';
+
+loadEnv();
+
+export const envSchema = z.object({
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+  DATABASE_URL: z
+    .string({ required_error: 'DATABASE_URL is required' })
+    .url('DATABASE_URL must be a valid URL')
+    .refine((value) => value.startsWith('postgres'), {
+      message: 'DATABASE_URL must point to a PostgreSQL instance',
+    }),
+  BETTER_AUTH_SECRET: z.string({ required_error: 'BETTER_AUTH_SECRET is required' }).min(1),
+  BETTER_AUTH_URL: z.string({ required_error: 'BETTER_AUTH_URL is required' }).url(),
+  NEXT_PUBLIC_BETTER_AUTH_URL: z
+    .string({ required_error: 'NEXT_PUBLIC_BETTER_AUTH_URL is required' })
+    .url(),
+  WA_OUTBOUND_URL: z.string({ required_error: 'WA_OUTBOUND_URL is required' }).url(),
+  FILES_DIR: z
+    .string({ required_error: 'FILES_DIR is required' })
+    .min(1)
+    .transform((dir) => path.resolve(dir)),
+});
+
+const env = envSchema.parse(process.env);
+
+export default env;


### PR DESCRIPTION
## Summary
- add a shared env.mjs loader that validates database, Better Auth, WhatsApp, and file storage variables
- update drizzle configuration and database client to consume the validated environment values
- align sample env settings and docker compose with the WhatsApp outbound gateway configuration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8bc67643c832ba38a81d97efb9f36