### PR TITLE
Add WhatsApp webhook and POS APIs

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,27 @@
+import { sql } from 'drizzle-orm';
+
+import { db } from '@/db';
+
+export const runtime = 'nodejs';
+
+export async function GET(): Promise<Response> {
+  try {
+    await db.execute(sql`select 1 as ok`);
+    return Response.json({
+      status: 'ok',
+      database: 'connected',
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return Response.json(
+      {
+        status: 'unhealthy',
+        database: 'unreachable',
+        error: message,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 503 },
+    );
+  }
+}

--- a/app/api/pos/invoices/route.ts
+++ b/app/api/pos/invoices/route.ts
@@ -1,0 +1,149 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+
+import { db } from '@/db';
+import { invoiceItems, invoices } from '@/db/schema/app';
+import {
+  calculateTotals,
+  formatDocumentNumber,
+  getInvoiceWithRelations,
+  toPgNumeric,
+} from '@/lib/pos';
+import { ensureWhatsAppJid, sendWhatsAppTextMessage } from '@/lib/wa';
+
+export const runtime = 'nodejs';
+
+const invoiceItemSchema = z.object({
+  productId: z.string().uuid().optional().nullable(),
+  description: z.string().min(1, 'Description is required'),
+  quantity: z.number().int().positive('Quantity must be greater than zero'),
+  unitPrice: z.number().nonnegative('Unit price cannot be negative'),
+  discount: z.number().nonnegative().default(0),
+});
+
+const invoiceSchema = z.object({
+  customerId: z.string().uuid(),
+  ticketId: z.string().uuid().optional().nullable(),
+  quotationId: z.string().uuid().optional().nullable(),
+  invoiceNumber: z.string().optional(),
+  invoiceDate: z.string().optional(),
+  dueDate: z.string(),
+  status: z.string().default('draft'),
+  taxRate: z.number().default(6),
+  notes: z.string().optional(),
+  paymentMethod: z.string().optional(),
+  createdBy: z.string().uuid().optional(),
+  items: z.array(invoiceItemSchema).min(1, 'At least one line item is required'),
+});
+
+const currencyFormatter = new Intl.NumberFormat('en-MY', {
+  style: 'currency',
+  currency: 'MYR',
+});
+
+export async function GET(request: NextRequest): Promise<Response> {
+  const url = new URL(request.url);
+  const id = url.searchParams.get('id');
+  const number = url.searchParams.get('number');
+
+  if (!id && !number) {
+    return Response.json({ error: 'Provide an invoice id or number' }, { status: 400 });
+  }
+
+  try {
+    const invoice = await getInvoiceWithRelations({ id, number });
+    if (!invoice) {
+      return Response.json({ error: 'Invoice not found' }, { status: 404 });
+    }
+    return Response.json(invoice);
+  } catch (error) {
+    console.error('Failed to load invoice', error);
+    const message = error instanceof Error ? error.message : 'Unexpected error';
+    return Response.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const body = await request.json();
+  const parsed = invoiceSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const data = parsed.data;
+  const { subtotal, taxAmount, total } = calculateTotals(data.items, data.taxRate);
+  const invoiceNumber = data.invoiceNumber ?? formatDocumentNumber('INV');
+  const invoiceDate = data.invoiceDate ? new Date(data.invoiceDate) : new Date();
+  const dueDate = new Date(data.dueDate);
+
+  try {
+    const createdInvoice = await db.transaction(async (tx) => {
+      const [invoice] = await tx
+        .insert(invoices)
+        .values({
+          invoiceNumber,
+          customerId: data.customerId,
+          ticketId: data.ticketId ?? null,
+          quotationId: data.quotationId ?? null,
+          invoiceDate,
+          dueDate,
+          status: data.status ?? 'draft',
+          subtotal: toPgNumeric(subtotal),
+          taxRate: toPgNumeric(data.taxRate),
+          taxAmount: toPgNumeric(taxAmount),
+          total: toPgNumeric(total),
+          paidAmount: toPgNumeric(0),
+          notes: data.notes,
+          paymentMethod: data.paymentMethod,
+          createdBy: data.createdBy ?? null,
+        })
+        .returning();
+
+      if (!invoice) {
+        throw new Error('Invoice insert did not return a record');
+      }
+
+      await tx.insert(invoiceItems).values(
+        data.items.map((item) => ({
+          invoiceId: invoice.id,
+          productId: item.productId ?? null,
+          description: item.description,
+          quantity: item.quantity,
+          unitPrice: toPgNumeric(item.unitPrice),
+          discount: toPgNumeric(item.discount ?? 0),
+          totalPrice: toPgNumeric(item.quantity * item.unitPrice - (item.discount ?? 0)),
+        })),
+      );
+
+      return invoice;
+    });
+
+    const invoiceWithRelations = await getInvoiceWithRelations({ id: createdInvoice.id });
+    if (!invoiceWithRelations) {
+      throw new Error('Failed to load created invoice');
+    }
+
+    if (invoiceWithRelations.customer.phone) {
+      const totalFormatted = currencyFormatter.format(invoiceWithRelations.total);
+      const dueDateFormatted = invoiceWithRelations.dueDate
+        ? new Date(invoiceWithRelations.dueDate).toLocaleDateString('en-MY')
+        : '';
+      const message = `Halo ${invoiceWithRelations.customer.name}! Invois ${invoiceWithRelations.invoiceNumber} berjumlah ${totalFormatted}. Tarikh akhir: ${dueDateFormatted}. Sila hubungi kami jika perlukan bantuan.`;
+
+      try {
+        await sendWhatsAppTextMessage({
+          to: ensureWhatsAppJid(invoiceWithRelations.customer.phone),
+          message,
+        });
+      } catch (error) {
+        console.warn('Failed to send invoice WhatsApp notification', error);
+      }
+    }
+
+    return Response.json(invoiceWithRelations, { status: 201 });
+  } catch (error) {
+    console.error('Failed to create invoice', error);
+    const message = error instanceof Error ? error.message : 'Unexpected error';
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/pos/pdf/route.ts
+++ b/app/api/pos/pdf/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+
+import { renderInvoicePdf, renderQuotationPdf } from '@/lib/pdf';
+import { getInvoiceWithRelations, getQuotationWithRelations } from '@/lib/pos';
+
+export const runtime = 'nodejs';
+
+const pdfRequestSchema = z.object({
+  type: z.enum(['invoice', 'quotation']),
+  id: z.string().uuid().optional().nullable(),
+  number: z.string().optional().nullable(),
+  download: z.boolean().optional(),
+});
+
+type PdfRequest = z.infer<typeof pdfRequestSchema>;
+
+async function handlePdfGeneration(params: PdfRequest): Promise<Response> {
+  const { type, id, number, download } = params;
+
+  if (!id && !number) {
+    return Response.json({ error: 'Provide an id or number' }, { status: 400 });
+  }
+
+  if (type === 'invoice') {
+    const invoice = await getInvoiceWithRelations({ id, number });
+    if (!invoice) {
+      return Response.json({ error: 'Invoice not found' }, { status: 404 });
+    }
+    const pdfBytes = await renderInvoicePdf(invoice);
+    const fileName = `invoice-${invoice.invoiceNumber}.pdf`;
+    return respondWithPdf(pdfBytes, fileName, download);
+  }
+
+  const quotation = await getQuotationWithRelations({ id, number });
+  if (!quotation) {
+    return Response.json({ error: 'Quotation not found' }, { status: 404 });
+  }
+  const pdfBytes = await renderQuotationPdf(quotation);
+  const fileName = `quotation-${quotation.quotationNumber}.pdf`;
+  return respondWithPdf(pdfBytes, fileName, download);
+}
+
+function respondWithPdf(bytes: Uint8Array, filename: string, download?: boolean): Response {
+  const buffer = Buffer.from(bytes);
+  return new Response(buffer, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/pdf',
+      'Content-Length': buffer.length.toString(),
+      'Content-Disposition': `${download ? 'attachment' : 'inline'}; filename="${filename}"`,
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+function parseRequestData(data: Record<string, unknown>): PdfRequest | null {
+  const parsed = pdfRequestSchema.safeParse(data);
+  if (!parsed.success) {
+    return null;
+  }
+  return parsed.data;
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
+  const url = new URL(request.url);
+  const maybeData = parseRequestData({
+    type: url.searchParams.get('type') ?? undefined,
+    id: url.searchParams.get('id') ?? undefined,
+    number: url.searchParams.get('number') ?? undefined,
+    download: url.searchParams.get('download') === 'true',
+  });
+
+  if (!maybeData) {
+    return Response.json({ error: 'Invalid query parameters' }, { status: 400 });
+  }
+
+  try {
+    return await handlePdfGeneration(maybeData);
+  } catch (error) {
+    console.error('Failed to generate PDF (GET)', error);
+    const message = error instanceof Error ? error.message : 'Unexpected error';
+    return Response.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const body = await request.json();
+  const maybeData = parseRequestData(body);
+  if (!maybeData) {
+    return Response.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+
+  try {
+    return await handlePdfGeneration(maybeData);
+  } catch (error) {
+    console.error('Failed to generate PDF (POST)', error);
+    const message = error instanceof Error ? error.message : 'Unexpected error';
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/pos/quotations/route.ts
+++ b/app/api/pos/quotations/route.ts
@@ -1,0 +1,143 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+
+import { db } from '@/db';
+import { quotationItems, quotations } from '@/db/schema/app';
+import {
+  calculateTotals,
+  formatDocumentNumber,
+  getQuotationWithRelations,
+  toPgNumeric,
+} from '@/lib/pos';
+import { ensureWhatsAppJid, sendWhatsAppTextMessage } from '@/lib/wa';
+
+export const runtime = 'nodejs';
+
+const quotationItemSchema = z.object({
+  productId: z.string().uuid().optional().nullable(),
+  description: z.string().min(1, 'Description is required'),
+  quantity: z.number().int().positive('Quantity must be greater than zero'),
+  unitPrice: z.number().nonnegative('Unit price cannot be negative'),
+  discount: z.number().nonnegative().default(0),
+});
+
+const quotationSchema = z.object({
+  customerId: z.string().uuid(),
+  ticketId: z.string().uuid().optional().nullable(),
+  quotationNumber: z.string().optional(),
+  validUntil: z.string(),
+  status: z.string().default('draft'),
+  taxRate: z.number().default(6),
+  notes: z.string().optional(),
+  terms: z.string().optional(),
+  createdBy: z.string().uuid().optional(),
+  items: z.array(quotationItemSchema).min(1, 'At least one line item is required'),
+});
+
+const currencyFormatter = new Intl.NumberFormat('en-MY', {
+  style: 'currency',
+  currency: 'MYR',
+});
+
+export async function GET(request: NextRequest): Promise<Response> {
+  const url = new URL(request.url);
+  const id = url.searchParams.get('id');
+  const number = url.searchParams.get('number');
+
+  if (!id && !number) {
+    return Response.json({ error: 'Provide a quotation id or number' }, { status: 400 });
+  }
+
+  try {
+    const quotation = await getQuotationWithRelations({ id, number });
+    if (!quotation) {
+      return Response.json({ error: 'Quotation not found' }, { status: 404 });
+    }
+    return Response.json(quotation);
+  } catch (error) {
+    console.error('Failed to load quotation', error);
+    const message = error instanceof Error ? error.message : 'Unexpected error';
+    return Response.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const body = await request.json();
+  const parsed = quotationSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const data = parsed.data;
+  const { subtotal, taxAmount, total } = calculateTotals(data.items, data.taxRate);
+  const quotationNumber = data.quotationNumber ?? formatDocumentNumber('QUO');
+  const validUntil = new Date(data.validUntil);
+
+  try {
+    const createdQuotation = await db.transaction(async (tx) => {
+      const [quotation] = await tx
+        .insert(quotations)
+        .values({
+          quotationNumber,
+          customerId: data.customerId,
+          ticketId: data.ticketId ?? null,
+          validUntil,
+          status: data.status ?? 'draft',
+          subtotal: toPgNumeric(subtotal),
+          taxRate: toPgNumeric(data.taxRate),
+          taxAmount: toPgNumeric(taxAmount),
+          total: toPgNumeric(total),
+          notes: data.notes,
+          terms: data.terms,
+          createdBy: data.createdBy ?? null,
+        })
+        .returning();
+
+      if (!quotation) {
+        throw new Error('Quotation insert did not return a record');
+      }
+
+      await tx.insert(quotationItems).values(
+        data.items.map((item) => ({
+          quotationId: quotation.id,
+          productId: item.productId ?? null,
+          description: item.description,
+          quantity: item.quantity,
+          unitPrice: toPgNumeric(item.unitPrice),
+          discount: toPgNumeric(item.discount ?? 0),
+          totalPrice: toPgNumeric(item.quantity * item.unitPrice - (item.discount ?? 0)),
+        })),
+      );
+
+      return quotation;
+    });
+
+    const quotationWithRelations = await getQuotationWithRelations({ id: createdQuotation.id });
+    if (!quotationWithRelations) {
+      throw new Error('Failed to load created quotation');
+    }
+
+    if (quotationWithRelations.customer.phone) {
+      const totalFormatted = currencyFormatter.format(quotationWithRelations.total);
+      const validUntilFormatted = quotationWithRelations.validUntil
+        ? new Date(quotationWithRelations.validUntil).toLocaleDateString('en-MY')
+        : '';
+      const message = `Halo ${quotationWithRelations.customer.name}! Quotation ${quotationWithRelations.quotationNumber} berjumlah ${totalFormatted}. Sah sehingga ${validUntilFormatted}. Balas mesej ini untuk sebarang pertanyaan.`;
+
+      try {
+        await sendWhatsAppTextMessage({
+          to: ensureWhatsAppJid(quotationWithRelations.customer.phone),
+          message,
+        });
+      } catch (error) {
+        console.warn('Failed to send quotation WhatsApp notification', error);
+      }
+    }
+
+    return Response.json(quotationWithRelations, { status: 201 });
+  } catch (error) {
+    console.error('Failed to create quotation', error);
+    const message = error instanceof Error ? error.message : 'Unexpected error';
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/whatsapp/webhook/route.ts
+++ b/app/api/whatsapp/webhook/route.ts
@@ -1,0 +1,283 @@
+import { NextRequest } from 'next/server';
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+
+import { db } from '@/db';
+import {
+  customers,
+  whatsappMessages,
+  whatsappSessions,
+} from '@/db/schema/app';
+import { ensureWhatsAppJid, parseRemoteJid, sendWhatsAppTextMessage } from '@/lib/wa';
+
+export const runtime = 'nodejs';
+
+const baseEventSchema = z.object({
+  event: z.string(),
+  data: z.unknown(),
+});
+
+const messageKeySchema = z
+  .object({
+    id: z.string().optional(),
+  })
+  .partial();
+
+const messagePayloadSchema = z
+  .object({
+    conversation: z.string().optional(),
+    extendedTextMessage: z
+      .object({ text: z.string().optional() })
+      .partial()
+      .optional(),
+    imageMessage: z
+      .object({ caption: z.string().optional() })
+      .partial()
+      .optional(),
+    videoMessage: z
+      .object({ caption: z.string().optional() })
+      .partial()
+      .optional(),
+    buttonsResponseMessage: z
+      .object({ selectedDisplayText: z.string().optional() })
+      .partial()
+      .optional(),
+  })
+  .passthrough();
+
+const messageUpsertSchema = z.object({
+  event: z.literal('messages.upsert'),
+  data: z.object({
+    type: z.string(),
+    key: z.object({
+      id: z.string().optional(),
+      remoteJid: z.string(),
+      fromMe: z.boolean().optional(),
+    }),
+    message: messagePayloadSchema.optional(),
+    pushName: z.string().optional(),
+    timestamp: z.union([z.number(), z.string()]).optional(),
+  }),
+});
+
+const messageUpdateSchema = z.object({
+  event: z.literal('messages.update'),
+  data: z.array(
+    z.object({
+      key: messageKeySchema.optional(),
+      status: z.string().optional(),
+      update: z
+        .object({
+          status: z.string().optional(),
+        })
+        .partial()
+        .optional(),
+    }),
+  ),
+});
+
+const messageDeleteSchema = z.object({
+  event: z.literal('messages.delete'),
+  data: z.array(
+    z.object({
+      key: messageKeySchema.optional(),
+    }),
+  ),
+});
+
+type MessagePayload = z.infer<typeof messagePayloadSchema>;
+type MessageUpdate = z.infer<typeof messageUpdateSchema>['data'][number];
+type MessageDeletion = z.infer<typeof messageDeleteSchema>['data'][number];
+
+function extractMessageText(message?: MessagePayload): string | null {
+  if (!message) return null;
+  if (typeof message.conversation === 'string') {
+    return message.conversation;
+  }
+  if (typeof message.extendedTextMessage?.text === 'string') {
+    return message.extendedTextMessage.text;
+  }
+  if (typeof message.imageMessage?.caption === 'string') {
+    return message.imageMessage.caption;
+  }
+  if (typeof message.videoMessage?.caption === 'string') {
+    return message.videoMessage.caption;
+  }
+  if (typeof message.buttonsResponseMessage?.selectedDisplayText === 'string') {
+    return message.buttonsResponseMessage.selectedDisplayText;
+  }
+  return null;
+}
+
+function generateAutoReply(content: string | null): string | null {
+  if (!content) return null;
+  const lower = content.toLowerCase();
+
+  if (/(hi|hello|hey|hai)/.test(lower)) {
+    return 'Hai! 👋 Terima kasih menghubungi WhatsApp POS System kami. Saya boleh bantu semak status pembaikan atau info invois/quotation.';
+  }
+  if (lower.includes('status')) {
+    return 'Untuk semak status pembaikan, sila kongsi nombor tiket atau nombor telefon yang digunakan semasa check-in.';
+  }
+  if (lower.includes('quotation')) {
+    return 'Kami boleh hantar semula quotation terbaru melalui WhatsApp. Tolong berikan nombor tiket atau nama pelanggan.';
+  }
+  if (lower.includes('invoice') || lower.includes('bayar')) {
+    return 'Untuk bantuan invois atau pembayaran, sila maklumkan nombor invois atau nama pelanggan supaya kami boleh semak rekod.';
+  }
+  if (lower.includes('help') || lower.includes('bantuan')) {
+    return 'Kami sedia membantu! Nyatakan jika anda ingin semak status pembaikan, quotation, invois, atau ada soalan lain.';
+  }
+
+  return null;
+}
+
+async function getOrCreateSession(remoteJid: string) {
+  const parsed = parseRemoteJid(remoteJid);
+  const [existing] = await db
+    .select()
+    .from(whatsappSessions)
+    .where(eq(whatsappSessions.sessionId, remoteJid))
+    .limit(1);
+
+  const customerRecord = parsed.phoneNumber
+    ? (await db
+        .select()
+        .from(customers)
+        .where(eq(customers.phone, parsed.phoneNumber))
+        .limit(1))?.[0]
+    : undefined;
+
+  if (existing) {
+    await db
+      .update(whatsappSessions)
+      .set({
+        lastActivity: new Date(),
+        phoneNumber: parsed.phoneNumber || existing.phoneNumber,
+        customerId: customerRecord?.id ?? existing.customerId ?? null,
+      })
+      .where(eq(whatsappSessions.id, existing.id));
+
+    return existing;
+  }
+
+  const [created] = await db
+    .insert(whatsappSessions)
+    .values({
+      sessionId: remoteJid,
+      phoneNumber: parsed.phoneNumber || remoteJid,
+      isActive: true,
+      lastActivity: new Date(),
+      customerId: customerRecord?.id,
+    })
+    .returning();
+
+  if (!created) {
+    throw new Error('Failed to create WhatsApp session');
+  }
+
+  return created;
+}
+
+function toDate(timestamp?: number | string): Date {
+  if (!timestamp) return new Date();
+  const numeric = typeof timestamp === 'string' ? Number(timestamp) : timestamp;
+  if (Number.isNaN(numeric)) return new Date();
+  // Baileys emits seconds, convert if it looks like seconds.
+  return new Date(numeric > 1_000_000_000_000 ? numeric : numeric * 1000);
+}
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const payload = await request.json();
+  const parsedBase = baseEventSchema.safeParse(payload);
+  if (!parsedBase.success) {
+    return Response.json({ error: 'Invalid webhook payload' }, { status: 400 });
+  }
+
+  const { event } = parsedBase.data;
+
+  if (event === 'messages.upsert') {
+    const parsed = messageUpsertSchema.safeParse(payload);
+    if (!parsed.success) {
+      return Response.json({ error: 'Invalid messages.upsert payload' }, { status: 400 });
+    }
+
+    const { data } = parsed.data;
+    const session = await getOrCreateSession(data.key.remoteJid);
+    const messageText = extractMessageText(data.message);
+    const direction = data.key.fromMe ? 'outbound' : 'inbound';
+
+    await db.insert(whatsappMessages).values({
+      sessionId: session.id,
+      messageId: data.key.id,
+      direction,
+      messageContent: messageText ?? JSON.stringify(data.message ?? {}),
+      status: direction === 'inbound' ? 'received' : 'sent',
+      timestamp: toDate(data.timestamp),
+    });
+
+    if (direction === 'inbound') {
+      const reply = generateAutoReply(messageText);
+      if (reply) {
+        try {
+          const recipient = ensureWhatsAppJid(data.key.remoteJid);
+          await sendWhatsAppTextMessage({ to: recipient, message: reply });
+          await db.insert(whatsappMessages).values({
+            sessionId: session.id,
+            messageContent: reply,
+            direction: 'outbound',
+            status: 'sent',
+            timestamp: new Date(),
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Unknown error';
+          await db.insert(whatsappMessages).values({
+            sessionId: session.id,
+            messageContent: `Auto-reply failed: ${message}`,
+            direction: 'outbound',
+            status: 'failed',
+            timestamp: new Date(),
+          });
+          console.error('Failed to send auto-reply', error);
+        }
+      }
+    }
+
+    return Response.json({ success: true });
+  }
+
+  if (event === 'messages.update') {
+    const parsed = messageUpdateSchema.safeParse(payload);
+    if (parsed.success) {
+      const updates: MessageUpdate[] = parsed.data.data;
+      for (const update of updates) {
+        const messageId = update.key?.id;
+        const status = update.update?.status ?? update.status;
+        if (!messageId || !status) continue;
+        await db
+          .update(whatsappMessages)
+          .set({ status })
+          .where(eq(whatsappMessages.messageId, messageId));
+      }
+    }
+    return Response.json({ acknowledged: true });
+  }
+
+  if (event === 'messages.delete') {
+    const parsed = messageDeleteSchema.safeParse(payload);
+    if (parsed.success) {
+      const deletions: MessageDeletion[] = parsed.data.data;
+      for (const deletion of deletions) {
+        const messageId = deletion.key?.id;
+        if (!messageId) continue;
+        await db
+          .update(whatsappMessages)
+          .set({ status: 'deleted' })
+          .where(eq(whatsappMessages.messageId, messageId));
+      }
+    }
+    return Response.json({ acknowledged: true });
+  }
+
+  return Response.json({ ignored: true }, { status: 202 });
+}

--- a/lib/pdf.ts
+++ b/lib/pdf.ts
@@ -1,0 +1,223 @@
+import { format } from 'date-fns';
+import { PDFDocument, StandardFonts, rgb, type PDFFont, type PDFPage } from 'pdf-lib';
+
+import type { InvoiceWithRelations, QuotationWithRelations } from '@/types/pos';
+
+const currencyFormatter = new Intl.NumberFormat('en-MY', {
+  style: 'currency',
+  currency: 'MYR',
+});
+
+function formatCurrency(value: number): string {
+  return currencyFormatter.format(Math.round(value * 100) / 100);
+}
+
+function formatDate(value: string | Date | null | undefined): string {
+  if (!value) {
+    return '-';
+  }
+  const date = typeof value === 'string' ? new Date(value) : value;
+  return format(date, 'dd MMM yyyy');
+}
+
+interface PdfLayoutOptions {
+  title: string;
+  subtitle?: string;
+}
+
+async function createBaseDocument(options: PdfLayoutOptions): Promise<{
+  pdfDoc: PDFDocument;
+  page: PDFPage;
+  titleFont: PDFFont;
+  bodyFont: PDFFont;
+}> {
+  const pdfDoc = await PDFDocument.create();
+  const page = pdfDoc.addPage([595.28, 841.89]); // A4 size in points
+  const { height } = page.getSize();
+
+  const titleFont = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+  const bodyFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
+
+  page.drawText(options.title, {
+    x: 40,
+    y: height - 60,
+    size: 24,
+    font: titleFont,
+    color: rgb(0.1, 0.1, 0.1),
+  });
+
+  if (options.subtitle) {
+    page.drawText(options.subtitle, {
+      x: 40,
+      y: height - 90,
+      size: 12,
+      font: bodyFont,
+      color: rgb(0.35, 0.35, 0.35),
+    });
+  }
+
+  return { pdfDoc, page, titleFont, bodyFont };
+}
+
+function drawKeyValue(
+  page: PDFPage,
+  font: PDFFont,
+  label: string,
+  value: string,
+  position: { x: number; y: number },
+) {
+  page.drawText(`${label}:`, {
+    x: position.x,
+    y: position.y,
+    size: 11,
+    font,
+    color: rgb(0.35, 0.35, 0.35),
+  });
+  page.drawText(value, {
+    x: position.x + 120,
+    y: position.y,
+    size: 11,
+    font,
+    color: rgb(0.05, 0.05, 0.05),
+  });
+}
+
+function drawLineItems(
+  page: PDFPage,
+  font: PDFFont,
+  startY: number,
+  items: Array<{ description: string; quantity: number; unitPrice: number; totalPrice: number }>,
+) {
+  let currentY = startY;
+
+  page.drawText('Description', { x: 40, y: currentY, size: 11, font, color: rgb(0, 0, 0) });
+  page.drawText('Qty', { x: 320, y: currentY, size: 11, font, color: rgb(0, 0, 0) });
+  page.drawText('Unit Price', { x: 360, y: currentY, size: 11, font, color: rgb(0, 0, 0) });
+  page.drawText('Amount', { x: 460, y: currentY, size: 11, font, color: rgb(0, 0, 0) });
+
+  currentY -= 20;
+
+  items.forEach((item) => {
+    page.drawText(item.description, { x: 40, y: currentY, size: 10, font, color: rgb(0.1, 0.1, 0.1) });
+    page.drawText(String(item.quantity), { x: 320, y: currentY, size: 10, font, color: rgb(0.1, 0.1, 0.1) });
+    page.drawText(formatCurrency(item.unitPrice), { x: 360, y: currentY, size: 10, font, color: rgb(0.1, 0.1, 0.1) });
+    page.drawText(formatCurrency(item.totalPrice), { x: 460, y: currentY, size: 10, font, color: rgb(0.1, 0.1, 0.1) });
+    currentY -= 18;
+  });
+
+  return currentY;
+}
+
+export async function renderInvoicePdf(invoice: InvoiceWithRelations): Promise<Uint8Array> {
+  const { pdfDoc, page, bodyFont, titleFont } = await createBaseDocument({
+    title: 'Invoice',
+    subtitle: `${invoice.invoiceNumber} • ${formatDate(invoice.invoiceDate)}`,
+  });
+  const { height } = page.getSize();
+
+  drawKeyValue(page, bodyFont, 'Customer', invoice.customer.name, { x: 40, y: height - 130 });
+  drawKeyValue(page, bodyFont, 'Phone', invoice.customer.phone ?? '-', { x: 40, y: height - 150 });
+  drawKeyValue(page, bodyFont, 'Email', invoice.customer.email ?? '-', { x: 40, y: height - 170 });
+
+  drawKeyValue(page, bodyFont, 'Invoice Date', formatDate(invoice.invoiceDate), { x: 320, y: height - 130 });
+  drawKeyValue(page, bodyFont, 'Due Date', formatDate(invoice.dueDate), { x: 320, y: height - 150 });
+  drawKeyValue(page, bodyFont, 'Status', invoice.status, { x: 320, y: height - 170 });
+
+  const lineItemsY = drawLineItems(page, bodyFont, height - 210, invoice.items);
+
+  let summaryY = lineItemsY - 20;
+  page.drawLine({
+    start: { x: 320, y: summaryY + 10 },
+    end: { x: 520, y: summaryY + 10 },
+    thickness: 0.5,
+    color: rgb(0.7, 0.7, 0.7),
+  });
+  drawKeyValue(page, bodyFont, 'Subtotal', formatCurrency(invoice.subtotal), { x: 320, y: summaryY });
+  summaryY -= 18;
+  drawKeyValue(page, bodyFont, `Tax (${invoice.taxRate}% )`, formatCurrency(invoice.taxAmount), {
+    x: 320,
+    y: summaryY,
+  });
+  summaryY -= 18;
+  drawKeyValue(page, titleFont, 'Total', formatCurrency(invoice.total), { x: 320, y: summaryY });
+  summaryY -= 18;
+  drawKeyValue(page, bodyFont, 'Paid', formatCurrency(invoice.paidAmount), { x: 320, y: summaryY });
+  summaryY -= 18;
+  drawKeyValue(page, bodyFont, 'Balance', formatCurrency(invoice.balance ?? 0), { x: 320, y: summaryY });
+
+  if (invoice.notes) {
+    page.drawText('Notes', { x: 40, y: summaryY - 40, size: 11, font: titleFont, color: rgb(0, 0, 0) });
+    page.drawText(invoice.notes, {
+      x: 40,
+      y: summaryY - 60,
+      size: 10,
+      font: bodyFont,
+      color: rgb(0.2, 0.2, 0.2),
+      maxWidth: 480,
+      lineHeight: 14,
+    });
+  }
+
+  return pdfDoc.save();
+}
+
+export async function renderQuotationPdf(quotation: QuotationWithRelations): Promise<Uint8Array> {
+  const { pdfDoc, page, bodyFont, titleFont } = await createBaseDocument({
+    title: 'Quotation',
+    subtitle: `${quotation.quotationNumber} • Valid until ${formatDate(quotation.validUntil)}`,
+  });
+  const { height } = page.getSize();
+
+  drawKeyValue(page, bodyFont, 'Customer', quotation.customer.name, { x: 40, y: height - 130 });
+  drawKeyValue(page, bodyFont, 'Phone', quotation.customer.phone ?? '-', { x: 40, y: height - 150 });
+  drawKeyValue(page, bodyFont, 'Email', quotation.customer.email ?? '-', { x: 40, y: height - 170 });
+
+  drawKeyValue(page, bodyFont, 'Status', quotation.status, { x: 320, y: height - 130 });
+  drawKeyValue(page, bodyFont, 'Valid Until', formatDate(quotation.validUntil), { x: 320, y: height - 150 });
+
+  const lineItemsY = drawLineItems(page, bodyFont, height - 210, quotation.items);
+
+  let summaryY = lineItemsY - 20;
+  page.drawLine({
+    start: { x: 320, y: summaryY + 10 },
+    end: { x: 520, y: summaryY + 10 },
+    thickness: 0.5,
+    color: rgb(0.7, 0.7, 0.7),
+  });
+  drawKeyValue(page, bodyFont, 'Subtotal', formatCurrency(quotation.subtotal), { x: 320, y: summaryY });
+  summaryY -= 18;
+  drawKeyValue(page, bodyFont, `Tax (${quotation.taxRate}% )`, formatCurrency(quotation.taxAmount), {
+    x: 320,
+    y: summaryY,
+  });
+  summaryY -= 18;
+  drawKeyValue(page, titleFont, 'Total', formatCurrency(quotation.total), { x: 320, y: summaryY });
+
+  if (quotation.notes) {
+    page.drawText('Notes', { x: 40, y: summaryY - 40, size: 11, font: titleFont, color: rgb(0, 0, 0) });
+    page.drawText(quotation.notes, {
+      x: 40,
+      y: summaryY - 60,
+      size: 10,
+      font: bodyFont,
+      color: rgb(0.2, 0.2, 0.2),
+      maxWidth: 480,
+      lineHeight: 14,
+    });
+  }
+
+  if (quotation.terms) {
+    page.drawText('Terms', { x: 40, y: summaryY - 110, size: 11, font: titleFont, color: rgb(0, 0, 0) });
+    page.drawText(quotation.terms, {
+      x: 40,
+      y: summaryY - 130,
+      size: 10,
+      font: bodyFont,
+      color: rgb(0.2, 0.2, 0.2),
+      maxWidth: 480,
+      lineHeight: 14,
+    });
+  }
+
+  return pdfDoc.save();
+}

--- a/lib/pos.ts
+++ b/lib/pos.ts
@@ -1,0 +1,192 @@
+import { eq } from 'drizzle-orm';
+
+import { db } from '@/db';
+import {
+  customers,
+  invoiceItems,
+  invoices,
+  quotationItems,
+  quotations,
+} from '@/db/schema/app';
+import type {
+  InvoiceWithRelations,
+  NormalizedInvoice,
+  NormalizedInvoiceItem,
+  NormalizedQuotation,
+  NormalizedQuotationItem,
+  QuotationWithRelations,
+} from '@/types/pos';
+
+function toNumber(value: unknown): number {
+  if (value === null || value === undefined) {
+    return 0;
+  }
+  if (typeof value === 'number') {
+    return value;
+  }
+  const parsed = Number(value);
+  if (Number.isNaN(parsed)) {
+    return 0;
+  }
+  return parsed;
+}
+
+function toNullableNumber(value: unknown): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+export function formatDocumentNumber(prefix: string): string {
+  const now = new Date();
+  const stamp = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}`;
+  return `${prefix}-${stamp}-${crypto.randomUUID().slice(0, 8).toUpperCase()}`;
+}
+
+export async function getInvoiceWithRelations(
+  identifier: { id?: string | null; number?: string | null },
+): Promise<InvoiceWithRelations | null> {
+  const { id, number } = identifier;
+  if (!id && !number) {
+    throw new Error('An invoice id or number is required');
+  }
+
+  const where = id ? eq(invoices.id, id) : eq(invoices.invoiceNumber, number!);
+  const [invoice] = await db.select().from(invoices).where(where).limit(1);
+  if (!invoice) {
+    return null;
+  }
+
+  const [customer] = await db
+    .select()
+    .from(customers)
+    .where(eq(customers.id, invoice.customerId))
+    .limit(1);
+
+  if (!customer) {
+    throw new Error('Invoice is missing linked customer');
+  }
+
+  const items = await db
+    .select()
+    .from(invoiceItems)
+    .where(eq(invoiceItems.invoiceId, invoice.id));
+
+  const quotation = invoice.quotationId
+    ? await getQuotationWithRelations({ id: invoice.quotationId })
+    : null;
+
+  const normalizedInvoice: NormalizedInvoice = {
+    ...invoice,
+    subtotal: toNumber(invoice.subtotal),
+    taxRate: toNumber(invoice.taxRate),
+    taxAmount: toNumber(invoice.taxAmount),
+    total: toNumber(invoice.total),
+    paidAmount: toNumber(invoice.paidAmount),
+    balance: toNullableNumber(invoice.balance),
+  };
+
+  const normalizedItems: NormalizedInvoiceItem[] = items.map((item) => ({
+    ...item,
+    unitPrice: toNumber(item.unitPrice),
+    discount: toNumber(item.discount),
+    totalPrice: toNumber(item.totalPrice),
+  }));
+
+  return {
+    ...normalizedInvoice,
+    customer,
+    quotation: quotation ? quotation : null,
+    items: normalizedItems,
+  };
+}
+
+export async function getQuotationWithRelations(
+  identifier: { id?: string | null; number?: string | null },
+): Promise<QuotationWithRelations | null> {
+  const { id, number } = identifier;
+  if (!id && !number) {
+    throw new Error('A quotation id or number is required');
+  }
+
+  const where = id ? eq(quotations.id, id) : eq(quotations.quotationNumber, number!);
+  const [quotation] = await db.select().from(quotations).where(where).limit(1);
+  if (!quotation) {
+    return null;
+  }
+
+  const [customer] = await db
+    .select()
+    .from(customers)
+    .where(eq(customers.id, quotation.customerId))
+    .limit(1);
+
+  if (!customer) {
+    throw new Error('Quotation is missing linked customer');
+  }
+
+  const items = await db
+    .select()
+    .from(quotationItems)
+    .where(eq(quotationItems.quotationId, quotation.id));
+
+  const normalizedQuotation: NormalizedQuotation = {
+    ...quotation,
+    subtotal: toNumber(quotation.subtotal),
+    taxRate: toNumber(quotation.taxRate),
+    taxAmount: toNumber(quotation.taxAmount),
+    total: toNumber(quotation.total),
+  };
+
+  const normalizedItems: NormalizedQuotationItem[] = items.map((item) => ({
+    ...item,
+    unitPrice: toNumber(item.unitPrice),
+    discount: toNumber(item.discount),
+    totalPrice: toNumber(item.totalPrice),
+  }));
+
+  return {
+    ...normalizedQuotation,
+    customer,
+    items: normalizedItems,
+  };
+}
+
+export interface LineItemInput {
+  productId?: string | null;
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  discount?: number;
+}
+
+export interface CalculatedTotals {
+  subtotal: number;
+  taxAmount: number;
+  total: number;
+}
+
+export function calculateTotals(
+  items: LineItemInput[],
+  taxRate: number,
+): CalculatedTotals {
+  const subtotal = items.reduce((acc, item) => {
+    const lineTotal = item.quantity * item.unitPrice - (item.discount ?? 0);
+    return acc + Math.max(lineTotal, 0);
+  }, 0);
+
+  const taxAmount = subtotal * (taxRate / 100);
+  const total = subtotal + taxAmount;
+
+  return {
+    subtotal: Math.round(subtotal * 100) / 100,
+    taxAmount: Math.round(taxAmount * 100) / 100,
+    total: Math.round(total * 100) / 100,
+  };
+}
+
+export function toPgNumeric(value: number): string {
+  return (Math.round(value * 100) / 100).toFixed(2);
+}

--- a/lib/wa.ts
+++ b/lib/wa.ts
@@ -1,0 +1,63 @@
+import env from '@/env.mjs';
+
+export interface SendWhatsAppMessagePayload {
+  to: string;
+  message: string;
+}
+
+export function ensureWhatsAppJid(recipient: string): string {
+  if (!recipient) {
+    throw new Error('WhatsApp recipient is required');
+  }
+
+  if (recipient.includes('@')) {
+    return recipient;
+  }
+
+  const digits = recipient.replace(/[^0-9+]/g, '');
+  if (!digits) {
+    throw new Error('WhatsApp recipient must include a phone number');
+  }
+
+  return `${digits}@s.whatsapp.net`;
+}
+
+export function parseRemoteJid(remoteJid: string): {
+  phoneNumber: string;
+  jid: string;
+  isGroup: boolean;
+} {
+  const [rawPhone = '', domain = ''] = remoteJid.split('@');
+  const phoneNumber = rawPhone.replace(/[^0-9+]/g, '');
+  return {
+    phoneNumber,
+    jid: remoteJid,
+    isGroup: domain === 'g.us',
+  };
+}
+
+export async function sendWhatsAppTextMessage(
+  payload: SendWhatsAppMessagePayload,
+): Promise<void> {
+  const { to, message } = payload;
+  const endpoint = new URL('/send', env.WA_OUTBOUND_URL);
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      to: ensureWhatsAppJid(to),
+      message,
+    }),
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text().catch(() => '');
+    throw new Error(
+      `Failed to send WhatsApp message: ${response.status} ${response.statusText} ${errorBody}`.trim(),
+    );
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "lucide-react": "^0.541.0",
         "next": "15.5.0",
         "next-themes": "^0.4.6",
+        "pdf-lib": "^1.17.1",
         "pg": "^8.16.3",
         "react": "19.1.0",
         "react-day-picker": "^9.9.0",
@@ -2082,6 +2083,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@peculiar/asn1-android": {
@@ -8203,6 +8222,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8242,6 +8267,24 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/pg": {
       "version": "8.16.3",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "lucide-react": "^0.541.0",
     "next": "15.5.0",
     "next-themes": "^0.4.6",
+    "pdf-lib": "^1.17.1",
     "pg": "^8.16.3",
     "react": "19.1.0",
     "react-day-picker": "^9.9.0",

--- a/types/pos.ts
+++ b/types/pos.ts
@@ -1,0 +1,54 @@
+import type { InferSelectModel } from 'drizzle-orm';
+
+import {
+  customers,
+  invoices,
+  invoiceItems,
+  quotations,
+  quotationItems,
+} from '@/db/schema/app';
+
+export type CustomerRecord = InferSelectModel<typeof customers>;
+export type InvoiceRecord = InferSelectModel<typeof invoices>;
+export type InvoiceItemRecord = InferSelectModel<typeof invoiceItems>;
+export type QuotationRecord = InferSelectModel<typeof quotations>;
+export type QuotationItemRecord = InferSelectModel<typeof quotationItems>;
+
+export interface NormalizedInvoice extends Omit<InvoiceRecord, 'subtotal' | 'taxRate' | 'taxAmount' | 'total' | 'paidAmount' | 'balance'> {
+  subtotal: number;
+  taxRate: number;
+  taxAmount: number;
+  total: number;
+  paidAmount: number;
+  balance: number | null;
+}
+
+export interface NormalizedInvoiceItem extends Omit<InvoiceItemRecord, 'unitPrice' | 'discount' | 'totalPrice'> {
+  unitPrice: number;
+  discount: number;
+  totalPrice: number;
+}
+
+export interface NormalizedQuotation extends Omit<QuotationRecord, 'subtotal' | 'taxRate' | 'taxAmount' | 'total'> {
+  subtotal: number;
+  taxRate: number;
+  taxAmount: number;
+  total: number;
+}
+
+export interface NormalizedQuotationItem extends Omit<QuotationItemRecord, 'unitPrice' | 'discount' | 'totalPrice'> {
+  unitPrice: number;
+  discount: number;
+  totalPrice: number;
+}
+
+export interface InvoiceWithRelations extends NormalizedInvoice {
+  customer: CustomerRecord;
+  quotation?: NormalizedQuotation | null;
+  items: NormalizedInvoiceItem[];
+}
+
+export interface QuotationWithRelations extends NormalizedQuotation {
+  customer: CustomerRecord;
+  items: NormalizedQuotationItem[];
+}


### PR DESCRIPTION
## Summary
- add a WhatsApp webhook route that persists chat sessions/messages and sends contextual auto-replies
- introduce POS invoice, quotation, and PDF routes backed by Drizzle models with WhatsApp notifications
- add shared helpers for WhatsApp messaging, POS calculations, PDF rendering, and a database-backed health check

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8bdfb7e0c832b8516fd473ac7ac6e