### PR TITLE
Adjust Docker services for dedicated WA gateway port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,10 @@
 # Copy this file to .env and modify as needed
 
 # Database Configuration
-DATABASE_URL=postgresql://postgres:postgres@postgres:5432/postgres
-POSTGRES_DB=postgres
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
+DATABASE_URL=postgresql://appuser:supersecret123@postgres:5432/appdb
+POSTGRES_DB=appdb
+POSTGRES_USER=appuser
+POSTGRES_PASSWORD=supersecret123
 
 # Authentication
 BETTER_AUTH_SECRET=your_secret_key_here
@@ -13,7 +13,7 @@ BETTER_AUTH_URL=http://localhost:3000
 NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:3000
 
 # WhatsApp Gateway
-WA_OUTBOUND_URL=http://wa:3000
+WA_OUTBOUND_URL=http://wa:8080/send
 
 # File Storage
 FILES_DIR=./files

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,9 +6,9 @@ services:
     container_name: postgres
     restart: unless-stopped
     environment:
-      POSTGRES_DB: ${POSTGRES_DB:-postgres}
-      POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-appdb}
+      POSTGRES_USER: ${POSTGRES_USER:-appuser}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-supersecret123}
     ports:
       - "5432:5432"
     volumes:
@@ -33,15 +33,13 @@ services:
     container_name: wa
     restart: unless-stopped
     environment:
-      PORT: 3000
-      APP_WEBHOOK_URL: http://app:3000/api/wa/webhook
+      PORT: 8080
+      APP_WEBHOOK_URL: http://app:3000/api/whatsapp/webhook
       LOG_LEVEL: info
     ports:
-      - "3001:3000"
+      - "8080:8080"
     volumes:
       - wa_store:/app/store
-    depends_on:
-      - app
 
   app:
     build:
@@ -56,13 +54,12 @@ services:
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:3000}
       NEXT_PUBLIC_BETTER_AUTH_URL: ${NEXT_PUBLIC_BETTER_AUTH_URL:-http://localhost:3000}
       REDIS_URL: redis://redis:6379
-      WA_OUTBOUND_URL: ${WA_OUTBOUND_URL:-http://wa:3000}
+      WA_OUTBOUND_URL: ${WA_OUTBOUND_URL:-http://wa:8080/send}
     ports:
       - "3000:3000"
     depends_on:
       - postgres
       - redis
-      - wa
 
 volumes:
   pgdata:

--- a/wa/Dockerfile
+++ b/wa/Dockerfile
@@ -8,6 +8,6 @@ RUN npm install --production
 
 COPY . .
 
-EXPOSE 3000
+EXPOSE 8080
 
 CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- expose the WhatsApp gateway on port 8080, point it at the updated webhook URL, and remove the circular dependency from docker-compose
- refresh environment defaults for the application and data services, including the outbound WhatsApp URL
- align the WhatsApp Dockerfile metadata with the new listening port

## Testing
- npm run docker:up *(fails: Docker CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8e17eab3c832b986637bc66a61e71