### PR TITLE
Refine WhatsApp gateway webhook and SOP automation

### DIFF
--- a/app/api/pos/invoices/route.ts
+++ b/app/api/pos/invoices/route.ts
@@ -135,7 +135,7 @@ export async function POST(request: NextRequest): Promise<Response> {
         await sendWhatsAppTextMessage(
           {
             to: ensureWhatsAppJid(invoiceWithRelations.customer.phone),
-            message,
+            text: message,
             metadata: {
               documentId: invoiceWithRelations.id,
               documentType: 'invoice',

--- a/app/api/pos/quotations/route.ts
+++ b/app/api/pos/quotations/route.ts
@@ -127,7 +127,7 @@ export async function POST(request: NextRequest): Promise<Response> {
         await sendWhatsAppTextMessage(
           {
             to: ensureWhatsAppJid(quoteWithRelations.customer.phone),
-            message,
+            text: message,
             metadata: {
               documentId: quoteWithRelations.id,
               documentType: 'quotation',

--- a/app/api/whatsapp/webhook/route.ts
+++ b/app/api/whatsapp/webhook/route.ts
@@ -1,280 +1,163 @@
 import { NextRequest } from 'next/server';
-import { eq } from 'drizzle-orm';
+import { desc, eq, or } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { db } from '@/db';
 import { customers, waMessages } from '@/db/schema';
 import logger from '@/lib/logger';
-import { ensureWhatsAppJid, parseRemoteJid, sendWhatsAppTextMessage } from '@/lib/wa';
+import { coerceSopMetadata, evaluateSopTransition } from '@/lib/wa-sop';
+import { normalizePhoneNumber, sendWhatsAppTextMessage } from '@/lib/wa';
 
 export const runtime = 'nodejs';
 
-type WaMessageStatus = (typeof waMessages.$inferInsert)['status'];
-
-const baseEventSchema = z.object({
-  event: z.string(),
-  data: z.unknown(),
+const inboundMessageSchema = z.object({
+  from: z.string().min(1, 'Sender is required'),
+  text: z.string().min(1, 'Message text is required'),
 });
 
-const messageKeySchema = z
-  .object({
-    id: z.string().optional(),
-  })
-  .partial();
+type InsertWaMessage = typeof waMessages.$inferInsert;
+type SopMetadata = ReturnType<typeof coerceSopMetadata>;
 
-const messagePayloadSchema = z
-  .object({
-    conversation: z.string().optional(),
-    extendedTextMessage: z
-      .object({ text: z.string().optional() })
-      .partial()
-      .optional(),
-    imageMessage: z
-      .object({ caption: z.string().optional() })
-      .partial()
-      .optional(),
-    videoMessage: z
-      .object({ caption: z.string().optional() })
-      .partial()
-      .optional(),
-    buttonsResponseMessage: z
-      .object({ selectedDisplayText: z.string().optional() })
-      .partial()
-      .optional(),
-  })
-  .passthrough();
+type RawMetadata = Record<string, unknown> | null | undefined;
 
-const messageUpsertSchema = z.object({
-  event: z.literal('messages.upsert'),
-  data: z.object({
-    type: z.string(),
-    key: z.object({
-      id: z.string().optional(),
-      remoteJid: z.string(),
-      fromMe: z.boolean().optional(),
-    }),
-    message: messagePayloadSchema.optional(),
-    pushName: z.string().optional(),
-    timestamp: z.union([z.number(), z.string()]).optional(),
-  }),
-});
-
-const messageUpdateSchema = z.object({
-  event: z.literal('messages.update'),
-  data: z.array(
-    z.object({
-      key: messageKeySchema.optional(),
-      status: z.string().optional(),
-      update: z
-        .object({
-          status: z.string().optional(),
-        })
-        .partial()
-        .optional(),
-    }),
-  ),
-});
-
-const messageDeleteSchema = z.object({
-  event: z.literal('messages.delete'),
-  data: z.array(
-    z.object({
-      key: messageKeySchema.optional(),
-    }),
-  ),
-});
-
-type MessagePayload = z.infer<typeof messagePayloadSchema>;
-type MessageUpdate = z.infer<typeof messageUpdateSchema>['data'][number];
-type MessageDeletion = z.infer<typeof messageDeleteSchema>['data'][number];
-
-function extractMessageText(message?: MessagePayload): string | null {
-  if (!message) return null;
-  if (typeof message.conversation === 'string') {
-    return message.conversation;
+function extractSopMetadata(metadata: RawMetadata): SopMetadata {
+  if (metadata && typeof metadata === 'object' && 'sop' in metadata) {
+    return coerceSopMetadata((metadata as Record<string, unknown>).sop);
   }
-  if (typeof message.extendedTextMessage?.text === 'string') {
-    return message.extendedTextMessage.text;
-  }
-  if (typeof message.imageMessage?.caption === 'string') {
-    return message.imageMessage.caption;
-  }
-  if (typeof message.videoMessage?.caption === 'string') {
-    return message.videoMessage.caption;
-  }
-  if (typeof message.buttonsResponseMessage?.selectedDisplayText === 'string') {
-    return message.buttonsResponseMessage.selectedDisplayText;
-  }
-  return null;
+
+  return coerceSopMetadata(metadata);
 }
 
-function generateAutoReply(content: string | null): string | null {
-  if (!content) return null;
-  const lower = content.toLowerCase();
-
-  if (/(hi|hello|hey|hai)/.test(lower)) {
-    return 'Hai! 👋 Terima kasih menghubungi WhatsApp POS System kami. Saya boleh bantu semak status pembaikan atau info invois/quotation.';
-  }
-  if (lower.includes('status')) {
-    return 'Untuk semak status pembaikan, sila kongsi nombor tiket atau nombor telefon yang digunakan semasa check-in.';
-  }
-  if (lower.includes('quotation')) {
-    return 'Kami boleh hantar semula quotation terbaru melalui WhatsApp. Tolong berikan nombor tiket atau nama pelanggan.';
-  }
-  if (lower.includes('invoice') || lower.includes('bayar')) {
-    return 'Untuk bantuan invois atau pembayaran, sila maklumkan nombor invois atau nama pelanggan supaya kami boleh semak rekod.';
-  }
-  if (lower.includes('help') || lower.includes('bantuan')) {
-    return 'Kami sedia membantu! Nyatakan jika anda ingin semak status pembaikan, quotation, invois, atau ada soalan lain.';
-  }
-
-  return null;
-}
-
-async function findCustomerIdByPhone(phoneNumber: string | null): Promise<string | null> {
-  if (!phoneNumber) {
+async function findCustomerIdByPhone(msisdn: string): Promise<string | null> {
+  if (!msisdn) {
     return null;
   }
 
-  const [customer] = await db
+  const plain = msisdn.replace(/^\+/, '');
+  const [record] = await db
     .select({ id: customers.id })
     .from(customers)
-    .where(eq(customers.phone, phoneNumber))
+    .where(or(eq(customers.phone, msisdn), eq(customers.phone, plain)))
     .limit(1);
 
-  return customer?.id ?? null;
+  return record?.id ?? null;
 }
 
-function normalizeMessageStatus(status?: string): WaMessageStatus {
-  const allowed: WaMessageStatus[] = [
-    'pending',
-    'sent',
-    'delivered',
-    'read',
-    'failed',
-    'received',
-    'deleted',
-  ];
-
-  if (!status) {
-    return 'pending';
-  }
-
-  const normalized = status.toLowerCase() as WaMessageStatus;
-  return allowed.includes(normalized) ? normalized : 'pending';
-}
-
-function toDate(timestamp?: number | string): Date {
-  if (!timestamp) return new Date();
-  const numeric = typeof timestamp === 'string' ? Number(timestamp) : timestamp;
-  if (Number.isNaN(numeric)) return new Date();
-  // Baileys emits seconds, convert if it looks like seconds.
-  return new Date(numeric > 1_000_000_000_000 ? numeric : numeric * 1000);
+async function insertWaMessage(values: InsertWaMessage): Promise<typeof waMessages.$inferSelect | null> {
+  const [record] = await db.insert(waMessages).values(values).returning();
+  return record ?? null;
 }
 
 export async function POST(request: NextRequest): Promise<Response> {
-  const payload = await request.json();
-  const parsedBase = baseEventSchema.safeParse(payload);
-  if (!parsedBase.success) {
+  const payload = await request
+    .json()
+    .catch(() => null);
+
+  const parsed = inboundMessageSchema.safeParse(payload);
+  if (!parsed.success) {
     return Response.json({ error: 'Invalid webhook payload' }, { status: 400 });
   }
 
-  const { event } = parsedBase.data;
+  const { from, text } = parsed.data;
+  const normalizedFrom = normalizePhoneNumber(from);
+  if (!normalizedFrom) {
+    return Response.json({ error: 'Invalid sender phone number' }, { status: 400 });
+  }
 
-  if (event === 'messages.upsert') {
-    const parsed = messageUpsertSchema.safeParse(payload);
-    if (!parsed.success) {
-      return Response.json({ error: 'Invalid messages.upsert payload' }, { status: 400 });
-    }
+  const sessionId = normalizedFrom.replace(/^\+/, '');
 
-    const { data } = parsed.data;
-    const parsedJid = parseRemoteJid(data.key.remoteJid);
-    const customerId = await findCustomerIdByPhone(parsedJid.phoneNumber || null);
-    const messageText = extractMessageText(data.message);
-    const direction = data.key.fromMe ? 'outbound' : 'inbound';
+  try {
+    const [previousMessage] = await db
+      .select({ metadata: waMessages.metadata })
+      .from(waMessages)
+      .where(eq(waMessages.sessionId, sessionId))
+      .orderBy(desc(waMessages.createdAt))
+      .limit(1);
 
-    await db.insert(waMessages).values({
-      sessionId: parsedJid.jid,
-      customerId,
-      externalId: data.key.id,
-      direction,
-      body: messageText ?? JSON.stringify(data.message ?? {}),
-      status: direction === 'inbound' ? 'received' : 'sent',
-      sentAt: toDate(data.timestamp),
-      metadata: data.message ?? null,
+    const previousSop = extractSopMetadata(previousMessage?.metadata as RawMetadata);
+
+    const transition = evaluateSopTransition({
+      previousState: previousSop.state,
+      previousIntent: previousSop.intent,
+      inboundText: text,
     });
 
-    if (direction === 'inbound') {
-      const reply = generateAutoReply(messageText);
-      if (reply) {
-        try {
-          const recipient = ensureWhatsAppJid(data.key.remoteJid);
-          await sendWhatsAppTextMessage({
-            to: recipient,
-            message: reply,
-            metadata: {
-              source: 'auto-reply',
-              sessionId: parsedJid.jid,
-            },
-          });
-          await db.insert(waMessages).values({
-            sessionId: parsedJid.jid,
-            customerId,
-            body: reply,
-            direction: 'outbound',
-            status: 'sent',
-            sentAt: new Date(),
-          });
-        } catch (error) {
-          const message = error instanceof Error ? error.message : 'Unknown error';
-          await db.insert(waMessages).values({
-            sessionId: parsedJid.jid,
-            customerId,
-            body: `Auto-reply failed: ${message}`,
-            direction: 'outbound',
-            status: 'failed',
-            sentAt: new Date(),
-          });
-          logger.error({ err: error }, 'Failed to send auto-reply');
-        }
-      }
+    const customerId = await findCustomerIdByPhone(normalizedFrom);
+
+    const inboundRecord = await insertWaMessage({
+      sessionId,
+      customerId,
+      direction: 'inbound',
+      status: 'received',
+      body: text,
+      sentAt: new Date(),
+      metadata: {
+        from,
+        normalizedFrom,
+        sop: {
+          state: previousSop.state,
+          intent: transition.intent ?? previousSop.intent ?? null,
+          reference: transition.reference ?? previousSop.reference ?? null,
+        },
+      },
+    });
+
+    try {
+      await sendWhatsAppTextMessage({
+        to: normalizedFrom,
+        text: transition.reply,
+        metadata: {
+          sessionId,
+          source: 'sop-automation',
+          intent: transition.intent ?? previousSop.intent ?? null,
+          reference: transition.reference ?? previousSop.reference ?? null,
+          inboundMessageId: inboundRecord?.id ?? null,
+        },
+      });
+
+      await insertWaMessage({
+        sessionId,
+        customerId,
+        direction: 'outbound',
+        status: 'sent',
+        body: transition.reply,
+        sentAt: new Date(),
+        metadata: {
+          normalizedFrom,
+          respondsTo: inboundRecord?.id ?? null,
+          sop: {
+            state: transition.nextState,
+            intent: transition.intent ?? previousSop.intent ?? null,
+            reference: transition.reference ?? previousSop.reference ?? null,
+          },
+        },
+      });
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to send SOP reply');
+
+      await insertWaMessage({
+        sessionId,
+        customerId,
+        direction: 'outbound',
+        status: 'failed',
+        body: transition.reply,
+        sentAt: new Date(),
+        metadata: {
+          normalizedFrom,
+          respondsTo: inboundRecord?.id ?? null,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          sop: {
+            state: transition.nextState,
+            intent: transition.intent ?? previousSop.intent ?? null,
+            reference: transition.reference ?? previousSop.reference ?? null,
+          },
+        },
+      });
     }
 
     return Response.json({ success: true });
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to process WhatsApp webhook');
+    return Response.json({ error: 'Failed to process webhook' }, { status: 500 });
   }
-
-  if (event === 'messages.update') {
-    const parsed = messageUpdateSchema.safeParse(payload);
-    if (parsed.success) {
-      const updates: MessageUpdate[] = parsed.data.data;
-      for (const update of updates) {
-        const messageId = update.key?.id;
-        const status = update.update?.status ?? update.status;
-        if (!messageId || !status) continue;
-        await db
-          .update(waMessages)
-          .set({ status: normalizeMessageStatus(status) })
-          .where(eq(waMessages.externalId, messageId));
-      }
-    }
-    return Response.json({ acknowledged: true });
-  }
-
-  if (event === 'messages.delete') {
-    const parsed = messageDeleteSchema.safeParse(payload);
-    if (parsed.success) {
-      const deletions: MessageDeletion[] = parsed.data.data;
-      for (const deletion of deletions) {
-        const messageId = deletion.key?.id;
-        if (!messageId) continue;
-        await db
-          .update(waMessages)
-          .set({ status: 'deleted' })
-          .where(eq(waMessages.externalId, messageId));
-      }
-    }
-    return Response.json({ acknowledged: true });
-  }
-
-  return Response.json({ ignored: true }, { status: 202 });
 }

--- a/lib/wa-sop.ts
+++ b/lib/wa-sop.ts
@@ -1,0 +1,204 @@
+import { z } from 'zod';
+
+export type SopState =
+  | 'new'
+  | 'awaiting_intent'
+  | 'awaiting_reference'
+  | 'completed';
+
+export type SopIntent = 'status' | 'quotation' | 'invoice' | 'handoff';
+
+export interface SopMetadata {
+  state: SopState;
+  intent?: SopIntent | null;
+  reference?: string | null;
+}
+
+export const SOP_METADATA_SCHEMA = z
+  .object({
+    state: z.enum(['new', 'awaiting_intent', 'awaiting_reference', 'completed']).default('new'),
+    intent: z.enum(['status', 'quotation', 'invoice', 'handoff']).optional().nullable(),
+    reference: z.string().optional().nullable(),
+  })
+  .partial({ intent: true, reference: true });
+
+const WELCOME_MESSAGE = [
+  'Hai! 👋 Selamat datang ke WhatsApp POS System kami.',
+  'Bagaimana kami boleh bantu anda hari ini?',
+  '',
+  'Balas dengan pilihan berikut:',
+  '1 - Semak status pembaikan',
+  '2 - Minta salinan quotation',
+  '3 - Minta salinan invois',
+  '4 - Bercakap dengan staf kami',
+].join('\n');
+
+const UNKNOWN_INTENT_MESSAGE = [
+  'Maaf, kami tidak pasti permintaan anda.',
+  'Sila balas dengan nombor pilihan yang sesuai (1-4) atau jelaskan sama ada anda perlukan status, quotation, invois, atau ingin bercakap dengan staf.',
+].join(' ');
+
+const HANDOFF_MESSAGE =
+  'Baik, kami akan maklumkan pasukan sokongan kami untuk hubungi anda secepat mungkin. Terima kasih atas kesabaran anda!';
+
+const referencePrompts: Record<Exclude<SopIntent, 'handoff'>, string> = {
+  status: 'Baik! Untuk semak status, sila berikan nombor tiket atau nombor telefon yang digunakan semasa check-in.',
+  quotation: 'Baik! Untuk semak quotation, sila berikan nombor tiket, nombor quotation, atau nombor telefon pelanggan.',
+  invoice: 'Baik! Untuk semak invois, sila berikan nombor invois atau nombor telefon pelanggan.',
+};
+
+const referenceFollowups: Record<Exclude<SopIntent, 'handoff'>, string> = {
+  status: 'Kami perlukan nombor tiket atau nombor telefon untuk semak status. Sila cuba berikan rujukan yang sah.',
+  quotation: 'Untuk bantu dengan quotation, kami perlukan nombor rujukan seperti nombor tiket, quotation atau nombor telefon.',
+  invoice: 'Untuk cari invois yang betul, kami perlukan nombor invois atau nombor telefon pelanggan. Boleh cuba sekali lagi?',
+};
+
+function detectIntent(message: string): SopIntent | null {
+  const normalized = message.toLowerCase();
+
+  if (/(^|\s)(1|status|progress|baik pulih|repair|pembaikan)(\s|$)/.test(normalized)) {
+    return 'status';
+  }
+  if (/(^|\s)(2|quote|quotation|sebutharga|sebut harga)(\s|$)/.test(normalized)) {
+    return 'quotation';
+  }
+  if (/(^|\s)(3|invoice|invois|bill|bayar|bayaran|payment)(\s|$)/.test(normalized)) {
+    return 'invoice';
+  }
+  if (/(^|\s)(4|manusia|human|agent|staf|staff|pegawai|hubungi)(\s|$)/.test(normalized)) {
+    return 'handoff';
+  }
+
+  return null;
+}
+
+function sanitizeReference(message: string): string | null {
+  const trimmed = message.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const condensed = trimmed.replace(/\s+/g, ' ');
+  if (condensed.length < 3) {
+    return null;
+  }
+
+  return condensed;
+}
+
+function acknowledgement(intent: Exclude<SopIntent, 'handoff'>, reference: string): string {
+  switch (intent) {
+    case 'status':
+      return `Terima kasih! Kami akan semak status untuk rujukan "${reference}" dan hubungi anda semula dalam masa terdekat.`;
+    case 'quotation':
+      return `Terima kasih! Kami akan semak quotation untuk rujukan "${reference}" dan maklumkan anda secepat mungkin.`;
+    case 'invoice':
+      return `Terima kasih! Kami akan semak invois untuk rujukan "${reference}" dan kembali kepada anda sebentar lagi.`;
+    default:
+      return 'Terima kasih! Kami akan menyemak maklumat tersebut segera.';
+  }
+}
+
+export interface SopTransitionInput {
+  previousState: SopState;
+  previousIntent?: SopIntent | null;
+  inboundText: string;
+}
+
+export interface SopTransitionResult {
+  reply: string;
+  nextState: SopState;
+  intent?: SopIntent | null;
+  reference?: string | null;
+}
+
+export function evaluateSopTransition(input: SopTransitionInput): SopTransitionResult {
+  const baseState = input.previousState === 'completed' ? 'new' : input.previousState;
+  const text = input.inboundText ?? '';
+
+  switch (baseState) {
+    case 'new':
+      return {
+        reply: WELCOME_MESSAGE,
+        nextState: 'awaiting_intent',
+        intent: null,
+        reference: null,
+      };
+    case 'awaiting_intent': {
+      const intent = detectIntent(text);
+      if (!intent) {
+        return {
+          reply: UNKNOWN_INTENT_MESSAGE,
+          nextState: 'awaiting_intent',
+          intent: input.previousIntent ?? null,
+          reference: null,
+        };
+      }
+
+      if (intent === 'handoff') {
+        return {
+          reply: HANDOFF_MESSAGE,
+          nextState: 'completed',
+          intent,
+          reference: null,
+        };
+      }
+
+      return {
+        reply: referencePrompts[intent],
+        nextState: 'awaiting_reference',
+        intent,
+        reference: null,
+      };
+    }
+    case 'awaiting_reference': {
+      const intent = input.previousIntent ?? detectIntent(text) ?? null;
+      if (!intent || intent === 'handoff') {
+        return {
+          reply: UNKNOWN_INTENT_MESSAGE,
+          nextState: 'awaiting_intent',
+          intent: null,
+          reference: null,
+        };
+      }
+
+      const reference = sanitizeReference(text);
+      if (!reference) {
+        return {
+          reply: referenceFollowups[intent],
+          nextState: 'awaiting_reference',
+          intent,
+          reference: null,
+        };
+      }
+
+      return {
+        reply: acknowledgement(intent, reference),
+        nextState: 'completed',
+        intent,
+        reference,
+      };
+    }
+    case 'completed':
+    default:
+      return {
+        reply: WELCOME_MESSAGE,
+        nextState: 'awaiting_intent',
+        intent: null,
+        reference: null,
+      };
+  }
+}
+
+export function coerceSopMetadata(value: unknown): SopMetadata {
+  const parsed = SOP_METADATA_SCHEMA.safeParse(value);
+  if (!parsed.success) {
+    return { state: 'new', intent: null, reference: null };
+  }
+
+  return {
+    state: parsed.data.state ?? 'new',
+    intent: parsed.data.intent ?? null,
+    reference: parsed.data.reference ?? null,
+  };
+}


### PR DESCRIPTION
## Summary
- Refactor the WhatsApp gateway to normalize phone numbers, post `{from,text}` payloads to the app webhook, and expose a `{to,text}` `/send` endpoint with the new environment defaults.
- Introduce a SOP state machine module and update the webhook route to store inbound messages, derive conversation context, and dispatch automated replies recorded in `wa_messages`.
- Update the shared WhatsApp helper and POS notification routes to use the renamed `text` payload while preserving metadata logging.

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8e254023c832b866426eff2306828