### PR TITLE
feat: add ticket intake flow and automation dashboards

### DIFF
--- a/app/(dash)/tickets/_components/ticket-actions.tsx
+++ b/app/(dash)/tickets/_components/ticket-actions.tsx
@@ -1,0 +1,192 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+
+import { Button } from "@/components/ui/button"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+
+interface TicketActionsProps {
+  ticketId: string
+  ticketNumber: string
+  customerName: string
+  problemDescription: string
+  currentStatus: string
+  estimatedCost?: string | null
+  latestDiagnostic?: {
+    summary: string | null
+    recommendedActions: string | null
+    estimatedCost: string | null
+  } | null
+}
+
+type ActionKey =
+  | "begin-diagnosis"
+  | "send-diagnosis"
+  | "approve-repair"
+  | "send-update"
+  | "ready-pickup"
+  | "picked-up"
+
+function parseCost(value?: string | null): number | undefined {
+  if (!value) return undefined
+  const parsed = Number(value)
+  if (Number.isNaN(parsed)) {
+    return undefined
+  }
+  return parsed
+}
+
+export function TicketActions(props: TicketActionsProps) {
+  const router = useRouter()
+  const [pendingAction, setPendingAction] = useState<ActionKey | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  async function runAction(action: ActionKey, request: RequestInit & { endpoint: string }) {
+    setPendingAction(action)
+    setActionError(null)
+
+    try {
+      const response = await fetch(request.endpoint, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: request.body,
+        cache: "no-store",
+      })
+
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => ({}))) as { error?: unknown }
+        const message =
+          typeof payload.error === "string"
+            ? payload.error
+            : "Aksi gagal dijalankan. Sila cuba lagi."
+        setActionError(message)
+        return
+      }
+
+      router.refresh()
+    } catch (error) {
+      console.error(error)
+      setActionError("Ralat rangkaian semasa menjalankan tindakan.")
+    } finally {
+      setPendingAction(null)
+    }
+  }
+
+  const derivedSummary =
+    props.latestDiagnostic?.summary ||
+    `Isu yang dilaporkan: ${props.problemDescription.slice(0, 160)}`
+  const derivedActions =
+    props.latestDiagnostic?.recommendedActions ||
+    "Kami akan berkongsi cadangan pembaikan lengkap selepas ujian tambahan."
+  const derivedEstimate =
+    parseCost(props.latestDiagnostic?.estimatedCost) ?? parseCost(props.estimatedCost)
+
+  return (
+    <div className="space-y-3">
+      {actionError ? (
+        <Alert variant="destructive">
+          <AlertDescription>{actionError}</AlertDescription>
+        </Alert>
+      ) : null}
+      <div className="flex flex-wrap gap-2">
+        <Button
+          variant="outline"
+          disabled={pendingAction !== null}
+          onClick={() =>
+            runAction("begin-diagnosis", {
+              endpoint: `/api/tickets/${props.ticketId}/updates`,
+              body: JSON.stringify({
+                updateType: "status_change",
+                description: `Teknisi sedang memulakan diagnosis untuk tiket #${props.ticketNumber}.`,
+                status: "diagnosing",
+              }),
+            })
+          }
+        >
+          {pendingAction === "begin-diagnosis" ? "Mengemas kini..." : "Mulakan diagnosis"}
+        </Button>
+        <Button
+          variant="outline"
+          disabled={pendingAction !== null}
+          onClick={() =>
+            runAction("send-diagnosis", {
+              endpoint: `/api/tickets/${props.ticketId}/diagnose`,
+              body: JSON.stringify({
+                summary: derivedSummary,
+                recommendedActions: derivedActions,
+                estimatedCost: derivedEstimate,
+              }),
+            })
+          }
+        >
+          {pendingAction === "send-diagnosis" ? "Menghantar..." : "Hantar ringkasan diagnosis"}
+        </Button>
+        <Button
+          variant="outline"
+          disabled={pendingAction !== null}
+          onClick={() =>
+            runAction("approve-repair", {
+              endpoint: `/api/tickets/${props.ticketId}/diagnose`,
+              body: JSON.stringify({
+                summary: `Pembaikan untuk tiket #${props.ticketNumber} diluluskan.`,
+                recommendedActions: derivedActions,
+                estimatedCost: derivedEstimate,
+                approved: true,
+                approvalNotes: "Kami akan mula membaiki sebaik sahaja alat ganti disediakan.",
+              }),
+            })
+          }
+        >
+          {pendingAction === "approve-repair" ? "Menghantar..." : "Luluskan pembaikan"}
+        </Button>
+        <Button
+          variant="outline"
+          disabled={pendingAction !== null}
+          onClick={() =>
+            runAction("send-update", {
+              endpoint: `/api/tickets/${props.ticketId}/updates`,
+              body: JSON.stringify({
+                updateType: "progress",
+                description: `Kemajuan tiket #${props.ticketNumber}: ${props.currentStatus.replaceAll("_", " ")}.`,
+                notify: true,
+              }),
+            })
+          }
+        >
+          {pendingAction === "send-update" ? "Menghantar..." : "Hantar kemas kini"}
+        </Button>
+        <Button
+          variant="outline"
+          disabled={pendingAction !== null}
+          onClick={() =>
+            runAction("ready-pickup", {
+              endpoint: `/api/tickets/${props.ticketId}/pickup`,
+              body: JSON.stringify({
+                status: "ready_for_pickup",
+              }),
+            })
+          }
+        >
+          {pendingAction === "ready-pickup" ? "Menghantar..." : "Sedia untuk diambil"}
+        </Button>
+        <Button
+          variant="default"
+          disabled={pendingAction !== null}
+          onClick={() =>
+            runAction("picked-up", {
+              endpoint: `/api/tickets/${props.ticketId}/pickup`,
+              body: JSON.stringify({
+                status: "picked_up",
+              }),
+            })
+          }
+        >
+          {pendingAction === "picked-up" ? "Menghantar..." : "Tandakan sudah diambil"}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/app/(dash)/tickets/page.tsx
+++ b/app/(dash)/tickets/page.tsx
@@ -1,0 +1,161 @@
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+import { listTickets } from "@/lib/tickets"
+
+import { TicketActions } from "./_components/ticket-actions"
+
+const statusLabels: Record<string, { label: string; className: string }> = {
+  pending: { label: "Menunggu", className: "bg-amber-100 text-amber-700 dark:bg-amber-500/10 dark:text-amber-200" },
+  diagnosing: { label: "Diagnosis", className: "bg-blue-100 text-blue-700 dark:bg-blue-500/10 dark:text-blue-200" },
+  approved: { label: "Diluluskan", className: "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-200" },
+  in_progress: { label: "Sedang dibaiki", className: "bg-sky-100 text-sky-700 dark:bg-sky-500/10 dark:text-sky-200" },
+  completed: { label: "Selesai", className: "bg-indigo-100 text-indigo-700 dark:bg-indigo-500/10 dark:text-indigo-200" },
+  ready_for_pickup: { label: "Sedia diambil", className: "bg-teal-100 text-teal-700 dark:bg-teal-500/10 dark:text-teal-200" },
+  picked_up: { label: "Diambil", className: "bg-lime-100 text-lime-700 dark:bg-lime-500/10 dark:text-lime-200" },
+  cancelled: { label: "Dibatalkan", className: "bg-rose-100 text-rose-700 dark:bg-rose-500/10 dark:text-rose-200" },
+}
+
+const priorityLabels: Record<string, string> = {
+  low: "Rendah",
+  normal: "Normal",
+  high: "Tinggi",
+  urgent: "Segera",
+}
+
+function formatDate(value: Date | string | null | undefined): string {
+  if (!value) return "-"
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return "-"
+  return new Intl.DateTimeFormat("ms-MY", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date)
+}
+
+function formatCurrency(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) return "-"
+  const numeric = typeof value === "number" ? value : Number(value)
+  if (Number.isNaN(numeric)) return "-"
+  return new Intl.NumberFormat("ms-MY", { style: "currency", currency: "MYR" }).format(numeric)
+}
+
+export default async function TicketsPage() {
+  const tickets = await listTickets(40)
+
+  return (
+    <div className="flex flex-1 flex-col gap-6 py-6">
+      <div className="px-4 lg:px-6">
+        <div className="flex flex-col gap-2">
+          <h1 className="text-3xl font-semibold tracking-tight">Pengurusan Tiket Servis</h1>
+          <p className="text-muted-foreground text-sm md:text-base">
+            Pantau status pembaikan, rekod diagnosis dan automasikan mesej WhatsApp untuk setiap peringkat SOP.
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-4 px-4 lg:px-6">
+        {tickets.length === 0 ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>Tiada tiket</CardTitle>
+              <CardDescription>Belum ada tiket servis yang direkodkan. Mulakan dengan borang intake pelanggan.</CardDescription>
+            </CardHeader>
+          </Card>
+        ) : null}
+
+        {tickets.map((ticket) => {
+          const statusConfig = statusLabels[ticket.status] ?? statusLabels.pending
+          const priorityLabel = priorityLabels[ticket.priority ?? "normal"] ?? ticket.priority
+          const latestUpdate = ticket.latestUpdate
+          const latestDiagnostic = ticket.latestDiagnostic
+
+          return (
+            <Card key={ticket.id} className="shadow-sm">
+              <CardHeader className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                <div className="space-y-1">
+                  <CardTitle className="text-xl font-semibold">Tiket #{ticket.ticketNumber}</CardTitle>
+                  <CardDescription>
+                    {ticket.customer.name} · {ticket.deviceType} {ticket.deviceModel}
+                  </CardDescription>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge className={statusConfig.className}>{statusConfig.label}</Badge>
+                  {priorityLabel ? <Badge variant="outline">Keutamaan: {priorityLabel}</Badge> : null}
+                  {ticket.estimatedCost ? (
+                    <Badge variant="outline">Anggaran: {formatCurrency(ticket.estimatedCost)}</Badge>
+                  ) : null}
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid gap-4 md:grid-cols-3">
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium text-muted-foreground">Maklumat pelanggan</p>
+                    <p className="text-sm">{ticket.customer.name}</p>
+                    <p className="text-sm text-muted-foreground">{ticket.customer.phone}</p>
+                    {ticket.customer.email ? (
+                      <p className="text-sm text-muted-foreground">{ticket.customer.email}</p>
+                    ) : null}
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium text-muted-foreground">Peranti</p>
+                    <p className="text-sm">{ticket.deviceType} · {ticket.deviceModel}</p>
+                    {ticket.serialNumber ? (
+                      <p className="text-sm text-muted-foreground">SN: {ticket.serialNumber}</p>
+                    ) : null}
+                    <p className="text-sm text-muted-foreground">Dicipta: {formatDate(ticket.createdAt)}</p>
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium text-muted-foreground">Kemas kini terkini</p>
+                    {latestUpdate ? (
+                      <div className="space-y-1 text-sm">
+                        <p>{latestUpdate.description}</p>
+                        <p className="text-xs text-muted-foreground">{formatDate(latestUpdate.createdAt)}</p>
+                      </div>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">Tiada kemas kini lagi</p>
+                    )}
+                  </div>
+                </div>
+
+                <Separator />
+
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <p className="text-sm font-medium text-muted-foreground">Ringkasan diagnosis</p>
+                    {latestDiagnostic ? (
+                      <div className="space-y-2 text-sm">
+                        <p>{latestDiagnostic.summary}</p>
+                        {latestDiagnostic.recommendedActions ? (
+                          <p className="text-muted-foreground">Cadangan: {latestDiagnostic.recommendedActions}</p>
+                        ) : null}
+                        {latestDiagnostic.estimatedCost ? (
+                          <p className="text-muted-foreground">
+                            Anggaran: {formatCurrency(latestDiagnostic.estimatedCost)}
+                          </p>
+                        ) : null}
+                      </div>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">
+                        Belum ada diagnosis direkodkan. Gunakan butang tindakan pantas untuk menghantar ringkasan kepada pelanggan.
+                      </p>
+                    )}
+                  </div>
+                  <TicketActions
+                    ticketId={ticket.id}
+                    ticketNumber={ticket.ticketNumber}
+                    customerName={ticket.customer.name}
+                    problemDescription={ticket.problemDescription}
+                    currentStatus={ticket.status}
+                    estimatedCost={ticket.estimatedCost as string | null}
+                    latestDiagnostic={latestDiagnostic}
+                  />
+                </div>
+              </CardContent>
+            </Card>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/app/(dash)/whatsapp/page.tsx
+++ b/app/(dash)/whatsapp/page.tsx
@@ -1,170 +1,180 @@
-import { IconMessageCircleBolt, IconMessageCirclePlus, IconPhoneCall, IconRocket } from "@tabler/icons-react"
+import { desc, eq } from "drizzle-orm"
 
-import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
-import { getWhatsappInbox } from "@/lib/mock-data"
+import { db } from "@/db"
+import { customers, tickets, waMessages } from "@/db/schema"
+import { listTickets } from "@/lib/tickets"
 
-const channelStyles: Record<string, string> = {
-  Campaign: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
-  Finance: "bg-sky-500/10 text-sky-600 dark:text-sky-400",
-  Support: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
-  Success: "bg-indigo-500/10 text-indigo-600 dark:text-indigo-400",
-  Sales: "bg-rose-500/10 text-rose-600 dark:text-rose-400",
+import { TicketActions } from "../tickets/_components/ticket-actions"
+
+type WaMessageRecord = typeof waMessages.$inferSelect
+
+interface Thread {
+  key: string
+  ticketId: string | null
+  ticketNumber?: string | null
+  customerName: string
+  customerPhone?: string | null
+  lastMessage: WaMessageRecord
+  stage?: string | null
 }
 
-function initials(name: string) {
-  return name
-    .split(" ")
-    .map((part) => part[0])
-    .join("")
+function formatDate(value: Date | string | null | undefined): string {
+  if (!value) return "-"
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return "-"
+  return new Intl.DateTimeFormat("ms-MY", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date)
 }
 
 export default async function WhatsappPage() {
-  const inbox = await getWhatsappInbox()
-  const totalUnread = inbox.reduce((sum, conversation) => sum + conversation.unread, 0)
-  const activeConversations = inbox.length
+  const [ticketsList, messageRows] = await Promise.all([
+    listTickets(50),
+    db
+      .select({
+        message: waMessages,
+        customer: customers,
+        ticket: tickets,
+      })
+      .from(waMessages)
+      .leftJoin(customers, eq(waMessages.customerId, customers.id))
+      .leftJoin(tickets, eq(waMessages.ticketId, tickets.id))
+      .orderBy(desc(waMessages.sentAt))
+      .limit(50),
+  ])
+
+  const ticketsById = new Map(ticketsList.map((ticket) => [ticket.id, ticket]))
+
+  const inboundCount = messageRows.filter((row) => row.message.direction === "inbound").length
+  const outboundCount = messageRows.filter((row) => row.message.direction === "outbound").length
+  const failedCount = messageRows.filter((row) => row.message.status === "failed").length
+
+  const threadMap = new Map<string, Thread>()
+  for (const row of messageRows) {
+    const stage = typeof row.message.metadata === "object" && row.message.metadata
+      ? ((row.message.metadata as Record<string, unknown>).stage as string | undefined)
+      : undefined
+    const key = row.message.ticketId ?? row.customer?.id ?? row.message.sessionId
+    if (!threadMap.has(key)) {
+      threadMap.set(key, {
+        key,
+        ticketId: row.message.ticketId,
+        ticketNumber: row.ticket?.ticketNumber ?? undefined,
+        customerName: row.customer?.name ?? "Tidak dikenali",
+        customerPhone: row.customer?.phone ?? null,
+        lastMessage: row.message,
+        stage: stage ?? (typeof row.message.metadata === "object"
+          ? ((row.message.metadata as Record<string, unknown>).intent as string | undefined)
+          : undefined),
+      })
+    }
+  }
+
+  const threads = Array.from(threadMap.values()).slice(0, 12)
 
   return (
-    <div className="flex flex-1 flex-col gap-6 py-4 md:py-6">
+    <div className="flex flex-1 flex-col gap-6 py-6">
       <div className="px-4 lg:px-6">
         <div className="flex flex-col gap-2">
-          <h1 className="text-2xl font-semibold tracking-tight md:text-3xl">WhatsApp Control Center</h1>
+          <h1 className="text-3xl font-semibold tracking-tight">WhatsApp Automation Hub</h1>
           <p className="text-muted-foreground text-sm md:text-base">
-            Automate conversation routing, resolve tickets faster, and sync WhatsApp data back to POS.
+            Lihat perbualan terbaru, pantau status penghantaran dan gunakan tindakan pantas untuk menyelaraskan SOP pembaikan.
           </p>
         </div>
       </div>
 
       <div className="grid gap-4 px-4 lg:grid-cols-3 lg:px-6">
         <Card>
-          <CardHeader className="flex items-center justify-between">
-            <div>
-              <CardTitle className="text-lg">Active conversations</CardTitle>
-              <CardDescription>Live WhatsApp threads across teams</CardDescription>
-            </div>
-            <IconMessageCircleBolt className="text-muted-foreground size-7" />
+          <CardHeader>
+            <CardTitle>Mesej keluar</CardTitle>
+            <CardDescription>Jumlah mesej automasi dihantar 24 jam lepas</CardDescription>
           </CardHeader>
           <CardContent>
-            <p className="text-3xl font-semibold">{activeConversations}</p>
+            <p className="text-3xl font-semibold text-primary">{outboundCount}</p>
           </CardContent>
         </Card>
         <Card>
           <CardHeader>
-            <CardTitle className="text-lg">Unread messages</CardTitle>
-            <CardDescription>Queue prioritised by SLA policies</CardDescription>
+            <CardTitle>Mesej masuk</CardTitle>
+            <CardDescription>Untuk perhatian manual atau auto-reply</CardDescription>
           </CardHeader>
           <CardContent>
-            <p className="text-3xl font-semibold text-rose-500">{totalUnread}</p>
+            <p className="text-3xl font-semibold text-emerald-500">{inboundCount}</p>
           </CardContent>
         </Card>
         <Card>
           <CardHeader>
-            <CardTitle className="text-lg">Average response</CardTitle>
-            <CardDescription>Rolling 7 day performance</CardDescription>
+            <CardTitle>Gagal dihantar</CardTitle>
+            <CardDescription>Perlu tindakan semula atau semakan gateway</CardDescription>
           </CardHeader>
           <CardContent>
-            <p className="text-3xl font-semibold text-emerald-500">3m 42s</p>
+            <p className="text-3xl font-semibold text-rose-500">{failedCount}</p>
           </CardContent>
         </Card>
       </div>
 
-      <div className="px-4 lg:px-6">
-        <Card>
-          <CardHeader className="gap-4 pb-2 sm:flex sm:items-center sm:justify-between">
-            <div className="flex flex-col gap-1">
-              <CardTitle>Inbox</CardTitle>
-              <CardDescription>Real-time sync from the WhatsApp Business Platform.</CardDescription>
-            </div>
-            <div className="flex flex-col gap-2 sm:flex-row">
-              <Button variant="outline" className="gap-2">
-                <IconRocket className="size-4" />
-                Launch campaign
-              </Button>
-              <Button className="gap-2">
-                <IconMessageCirclePlus className="size-4" />
-                New chat
-              </Button>
-            </div>
-          </CardHeader>
-          <CardContent className="p-0">
-            <ScrollArea className="h-[420px]">
-              <div className="flex flex-col divide-y divide-border">
-                {inbox.map((conversation) => (
-                  <div key={conversation.id} className="hover:bg-muted/40 flex items-center gap-4 px-4 py-3 transition">
-                    <Avatar className="size-11">
-                      <AvatarFallback className="bg-primary/10 text-primary font-semibold">
-                        {initials(conversation.name)}
-                      </AvatarFallback>
-                    </Avatar>
-                    <div className="flex flex-1 flex-col gap-1">
-                      <div className="flex items-center justify-between gap-4">
-                        <div className="flex items-center gap-2">
-                          <span className="font-medium leading-tight">{conversation.name}</span>
-                          <Badge className={channelStyles[conversation.channel] ?? ""} variant="outline">
-                            {conversation.channel}
-                          </Badge>
-                        </div>
-                        <span className="text-muted-foreground text-xs">
-                          {new Date(conversation.timestamp).toLocaleTimeString("id-ID", {
-                            hour: "2-digit",
-                            minute: "2-digit",
-                          })}
-                        </span>
-                      </div>
-                      <p className="text-muted-foreground line-clamp-2 text-sm">
-                        {conversation.preview}
-                      </p>
-                    </div>
-                    {conversation.unread > 0 ? (
-                      <Badge className="bg-rose-500 text-white">{conversation.unread}</Badge>
-                    ) : (
-                      <IconPhoneCall className="text-muted-foreground size-5" />
-                    )}
-                  </div>
-                ))}
-              </div>
-            </ScrollArea>
-          </CardContent>
-        </Card>
-      </div>
+      <div className="space-y-4 px-4 lg:px-6">
+        {threads.length === 0 ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>Belum ada mesej</CardTitle>
+              <CardDescription>Kemaskini akan muncul di sini selepas automasi menghantar mesej keluar pertama.</CardDescription>
+            </CardHeader>
+          </Card>
+        ) : null}
 
-      <div className="px-4 lg:px-6">
-        <Card>
-          <CardHeader>
-            <CardTitle>Escalation matrix</CardTitle>
-            <CardDescription>How WhatsApp intents route into the POS + CRM stack.</CardDescription>
-          </CardHeader>
-          <CardContent className="flex flex-col gap-4">
-            <div className="grid gap-4 md:grid-cols-3">
-              <div className="border-border bg-muted/40 flex flex-col gap-2 rounded-lg border p-4">
-                <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Sales</h3>
-                <p className="text-sm text-muted-foreground">
-                  Auto-assigned to the sales pod with product catalog shortcuts and deal sync back to POS.
-                </p>
-              </div>
-              <div className="border-border bg-muted/40 flex flex-col gap-2 rounded-lg border p-4">
-                <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Support</h3>
-                <p className="text-sm text-muted-foreground">
-                  Conversational AI triages tickets before escalating to live agents with POS order context.
-                </p>
-              </div>
-              <div className="border-border bg-muted/40 flex flex-col gap-2 rounded-lg border p-4">
-                <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Finance</h3>
-                <p className="text-sm text-muted-foreground">
-                  Payment intents sync to invoicing workflows and trigger reminders automatically.
-                </p>
-              </div>
-            </div>
-            <Separator />
-            <p className="text-sm text-muted-foreground">
-              Need deeper automation? Connect additional flows through the automation builder or bring your own webhook for custom actions.
-            </p>
-          </CardContent>
-        </Card>
+        {threads.map((thread) => {
+          const ticket = thread.ticketId ? ticketsById.get(thread.ticketId) : null
+          const statusLabel = ticket ? ticket.status.replaceAll("_", " ") : "Tanpa tiket"
+          const stageLabel = thread.stage ? thread.stage.replaceAll("_", " ") : null
+
+          return (
+            <Card key={thread.key} className="shadow-sm">
+              <CardHeader className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                <div className="space-y-1">
+                  <CardTitle className="text-xl font-semibold">
+                    {thread.ticketNumber ? `Tiket #${thread.ticketNumber}` : thread.customerName}
+                  </CardTitle>
+                  <CardDescription>
+                    {thread.customerName}
+                    {thread.customerPhone ? ` · ${thread.customerPhone}` : ""}
+                  </CardDescription>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  {ticket ? <Badge variant="outline">Status tiket: {statusLabel}</Badge> : null}
+                  {stageLabel ? <Badge className="bg-indigo-100 text-indigo-700 dark:bg-indigo-500/10 dark:text-indigo-200">SOP: {stageLabel}</Badge> : null}
+                  <Badge variant="outline">{thread.lastMessage.direction === "outbound" ? "Keluar" : "Masuk"}</Badge>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-1 text-sm">
+                  <p className="font-medium text-muted-foreground">Mesej terakhir</p>
+                  <p>{thread.lastMessage.body}</p>
+                  <p className="text-xs text-muted-foreground">Dihantar pada {formatDate(thread.lastMessage.sentAt)}</p>
+                </div>
+
+                {ticket ? (
+                  <>
+                    <Separator />
+                    <TicketActions
+                      ticketId={ticket.id}
+                      ticketNumber={ticket.ticketNumber}
+                      customerName={ticket.customer.name}
+                      problemDescription={ticket.problemDescription}
+                      currentStatus={ticket.status}
+                      estimatedCost={ticket.estimatedCost as string | null}
+                      latestDiagnostic={ticket.latestDiagnostic}
+                    />
+                  </>
+                ) : null}
+              </CardContent>
+            </Card>
+          )
+        })}
       </div>
     </div>
   )

--- a/app/api/tickets/[id]/diagnose/route.ts
+++ b/app/api/tickets/[id]/diagnose/route.ts
@@ -1,0 +1,139 @@
+import { NextRequest } from 'next/server'
+import { eq } from 'drizzle-orm'
+import { z } from 'zod'
+
+import { db } from '@/db'
+import { diagnostics, tickets } from '@/db/schema'
+import logger from '@/lib/logger'
+import { getTicketById } from '@/lib/tickets'
+import { sendTicketWorkflowWhatsAppMessage } from '@/lib/wa-messaging'
+import { toPgNumeric } from '@/lib/pos'
+
+export const runtime = 'nodejs'
+
+type DiagnosticInsert = typeof diagnostics.$inferInsert
+type TicketInsert = typeof tickets.$inferInsert
+
+const diagnosisSchema = z.object({
+  summary: z.string().min(5, 'Diagnosis summary is required'),
+  findings: z.string().optional(),
+  recommendedActions: z.string().optional(),
+  estimatedCost: z.number().nonnegative().optional(),
+  technicianId: z.string().optional(),
+  approved: z.boolean().optional(),
+  approvedBy: z.string().optional(),
+  approvalNotes: z.string().optional(),
+})
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<Response> {
+  const ticketId = params.id
+  const body = await request.json().catch(() => null)
+  const parsed = diagnosisSchema.safeParse(body)
+
+  if (!parsed.success) {
+    return Response.json({ error: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const ticket = await getTicketById(ticketId)
+  if (!ticket) {
+    return Response.json({ error: 'Ticket not found' }, { status: 404 })
+  }
+
+  const data = parsed.data
+  const now = new Date()
+  const nextStatus =
+    data.approved === undefined ? 'diagnosing' : data.approved ? 'approved' : 'cancelled'
+
+  try {
+    const diagnosticRecord = await db.transaction(async (tx) => {
+      const insertValues: DiagnosticInsert = {
+        ticketId,
+        summary: data.summary,
+        findings: data.findings,
+        recommendedActions: data.recommendedActions,
+        technicianId: data.technicianId,
+        approved: data.approved ?? false,
+        approvedBy: data.approved ? data.approvedBy ?? null : null,
+        approvedAt: data.approved ? now : null,
+      }
+
+      if (data.estimatedCost !== undefined) {
+        insertValues.estimatedCost = toPgNumeric(data.estimatedCost)
+      }
+
+      const [record] = await tx.insert(diagnostics).values(insertValues).returning()
+      if (!record) {
+        throw new Error('Failed to save diagnostic record')
+      }
+
+      const updateValues: Partial<TicketInsert> = {
+        status: nextStatus,
+        technicianNotes: data.recommendedActions ?? data.summary,
+        updatedAt: now,
+      }
+
+      if (data.estimatedCost !== undefined) {
+        updateValues.estimatedCost = toPgNumeric(data.estimatedCost)
+      }
+
+      await tx.update(tickets).set(updateValues).where(eq(tickets.id, ticketId))
+
+      return record
+    })
+
+    const currencyFormatter = new Intl.NumberFormat('en-MY', {
+      style: 'currency',
+      currency: 'MYR',
+    })
+
+    const summaryParts = [
+      `Ringkasan diagnosis untuk tiket #${ticket.ticketNumber}: ${data.summary}.`,
+    ]
+
+    if (data.estimatedCost !== undefined) {
+      summaryParts.push(`Anggaran kos: ${currencyFormatter.format(data.estimatedCost)}.`)
+    }
+
+    if (data.recommendedActions) {
+      summaryParts.push(`Cadangan tindakan: ${data.recommendedActions}.`)
+    }
+
+    await sendTicketWorkflowWhatsAppMessage({
+      customerId: ticket.customer.id,
+      ticketId,
+      phone: ticket.customer.phone,
+      stage: 'diagnosis_summary',
+      text: summaryParts.join(' '),
+      metadata: {
+        diagnosticId: diagnosticRecord.id,
+      },
+    })
+
+    if (data.approved !== undefined) {
+      const approvalMessage = data.approved
+        ? `Kerja pembaikan untuk tiket #${ticket.ticketNumber} telah diluluskan. Kami akan mulakan servis sebaik sahaja bahagian disediakan.`
+        : `Pembaikan untuk tiket #${ticket.ticketNumber} ditangguhkan seperti permintaan anda. Beritahu kami jika mahu meneruskan kemudian.`
+
+      await sendTicketWorkflowWhatsAppMessage({
+        customerId: ticket.customer.id,
+        ticketId,
+        phone: ticket.customer.phone,
+        stage: 'diagnosis_approval',
+        text: data.approvalNotes ? `${approvalMessage} ${data.approvalNotes}` : approvalMessage,
+        metadata: {
+          approved: data.approved,
+          diagnosticId: diagnosticRecord.id,
+        },
+      })
+    }
+
+    return Response.json({ diagnostic: diagnosticRecord, status: nextStatus })
+  } catch (error) {
+    logger.error({ err: error, ticketId }, 'Failed to record diagnosis')
+    const message = error instanceof Error ? error.message : 'Unexpected error'
+    return Response.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/api/tickets/[id]/pickup/route.ts
+++ b/app/api/tickets/[id]/pickup/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest } from 'next/server'
+import { eq } from 'drizzle-orm'
+import { z } from 'zod'
+
+import { db } from '@/db'
+import { invoices, tickets } from '@/db/schema'
+import logger from '@/lib/logger'
+import { getTicketById } from '@/lib/tickets'
+import { sendTicketWorkflowWhatsAppMessage } from '@/lib/wa-messaging'
+
+export const runtime = 'nodejs'
+
+type TicketInsert = typeof tickets.$inferInsert
+type InvoiceSelect = typeof invoices.$inferSelect
+
+const pickupSchema = z.object({
+  status: z.enum(['ready_for_pickup', 'picked_up']).default('ready_for_pickup'),
+  message: z.string().optional(),
+  invoiceId: z.string().uuid().optional(),
+  paymentStatus: z.enum(['sent', 'paid', 'partial', 'overdue', 'draft', 'cancelled']).optional(),
+  notify: z.boolean().default(true),
+})
+
+const currencyFormatter = new Intl.NumberFormat('en-MY', {
+  style: 'currency',
+  currency: 'MYR',
+})
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<Response> {
+  const ticketId = params.id
+  const body = await request.json().catch(() => null)
+  const parsed = pickupSchema.safeParse(body)
+
+  if (!parsed.success) {
+    return Response.json({ error: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const ticket = await getTicketById(ticketId)
+  if (!ticket) {
+    return Response.json({ error: 'Ticket not found' }, { status: 404 })
+  }
+
+  const data = parsed.data
+  const now = new Date()
+  const stage = data.status === 'picked_up' ? 'pickup_complete' : 'pickup_ready'
+
+  try {
+    let invoiceRecord: InvoiceSelect | null = null
+
+    await db.transaction(async (tx) => {
+      const updateTicketValues: Partial<TicketInsert> = {
+        status: data.status,
+        updatedAt: now,
+      }
+
+      await tx.update(tickets).set(updateTicketValues).where(eq(tickets.id, ticketId))
+
+      if (data.invoiceId) {
+        const [invoice] = await tx
+          .select()
+          .from(invoices)
+          .where(eq(invoices.id, data.invoiceId))
+          .limit(1)
+
+        if (invoice) {
+          if (invoice.ticketId && invoice.ticketId !== ticketId) {
+            throw new Error('Invoice does not belong to ticket')
+          }
+
+          const nextInvoiceStatus = data.paymentStatus ?? (data.status === 'picked_up' ? 'paid' : 'sent')
+
+          await tx
+            .update(invoices)
+            .set({
+              status: nextInvoiceStatus,
+              updatedAt: now,
+            })
+            .where(eq(invoices.id, invoice.id))
+
+          invoiceRecord = { ...invoice, status: nextInvoiceStatus }
+        }
+      }
+    })
+
+    if (data.notify) {
+      const defaultReadyMessage = `Peranti ${ticket.deviceModel} anda kini sedia untuk diambil di kedai kami. Sila tunjukkan tiket #${ticket.ticketNumber} semasa pengambilan.`
+      const defaultPickupMessage = `Terima kasih ${ticket.customer.name}! Pembaikan untuk tiket #${ticket.ticketNumber} selesai dan telah diambil. Jumpa lagi.`
+      const baseMessage = data.message ?? (data.status === 'picked_up' ? defaultPickupMessage : defaultReadyMessage)
+
+      const details: string[] = []
+      if (invoiceRecord) {
+        const total = Number(invoiceRecord.total ?? 0)
+        const formattedTotal = Number.isFinite(total) ? currencyFormatter.format(total) : undefined
+        if (formattedTotal) {
+          details.push(`Jumlah invois ${invoiceRecord.number}: ${formattedTotal}.`)
+        }
+
+        details.push(`Status invois: ${invoiceRecord.status}.`)
+      }
+
+      await sendTicketWorkflowWhatsAppMessage({
+        customerId: ticket.customer.id,
+        ticketId,
+        phone: ticket.customer.phone,
+        stage,
+        text: details.length > 0 ? `${baseMessage} ${details.join(' ')}` : baseMessage,
+        metadata: {
+          invoiceId: invoiceRecord?.id ?? data.invoiceId ?? null,
+          invoiceStatus: invoiceRecord?.status ?? null,
+        },
+      })
+    }
+
+    return Response.json({ status: data.status })
+  } catch (error) {
+    logger.error({ err: error, ticketId }, 'Failed to process pickup update')
+    const message = error instanceof Error ? error.message : 'Unexpected error'
+    return Response.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/api/tickets/[id]/updates/route.ts
+++ b/app/api/tickets/[id]/updates/route.ts
@@ -1,0 +1,140 @@
+import { NextRequest } from 'next/server'
+import { eq } from 'drizzle-orm'
+import { z } from 'zod'
+
+import { db } from '@/db'
+import { ticketUpdates, tickets } from '@/db/schema'
+import logger from '@/lib/logger'
+import { getTicketById } from '@/lib/tickets'
+import { sendTicketWorkflowWhatsAppMessage } from '@/lib/wa-messaging'
+import { toPgNumeric } from '@/lib/pos'
+
+export const runtime = 'nodejs'
+
+type TicketUpdateInsert = typeof ticketUpdates.$inferInsert
+
+type TicketInsert = typeof tickets.$inferInsert
+
+const statusOptions = [
+  'pending',
+  'diagnosing',
+  'approved',
+  'in_progress',
+  'completed',
+  'ready_for_pickup',
+  'picked_up',
+  'cancelled',
+] as const
+
+type TicketStatus = (typeof statusOptions)[number]
+
+const updateSchema = z.object({
+  updateType: z.string().min(2, 'Update type is required'),
+  description: z.string().min(4, 'Description is required'),
+  imageUrl: z.string().url().optional(),
+  status: z.enum(statusOptions).optional(),
+  actualCost: z.number().nonnegative().optional(),
+  updatedBy: z.string().optional(),
+  notify: z.boolean().default(true),
+})
+
+function createStatusLabel(status: TicketStatus | undefined): string {
+  switch (status) {
+    case 'diagnosing':
+      return 'Diagnosis sedang dijalankan'
+    case 'approved':
+      return 'Pembaikan diluluskan'
+    case 'in_progress':
+      return 'Pembaikan sedang dilakukan'
+    case 'completed':
+      return 'Pembaikan siap'
+    case 'ready_for_pickup':
+      return 'Sedia untuk diambil'
+    case 'picked_up':
+      return 'Telah diambil'
+    case 'cancelled':
+      return 'Tiket dibatalkan'
+    default:
+      return 'Dalam giliran servis'
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<Response> {
+  const ticketId = params.id
+  const body = await request.json().catch(() => null)
+  const parsed = updateSchema.safeParse(body)
+
+  if (!parsed.success) {
+    return Response.json({ error: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const ticket = await getTicketById(ticketId)
+  if (!ticket) {
+    return Response.json({ error: 'Ticket not found' }, { status: 404 })
+  }
+
+  const data = parsed.data
+  const now = new Date()
+
+  try {
+    const record = await db.transaction(async (tx) => {
+      const insertValues: TicketUpdateInsert = {
+        ticketId,
+        updateType: data.updateType,
+        description: data.description,
+        imageUrl: data.imageUrl,
+        updatedBy: data.updatedBy ?? ticket.createdBy ?? 'system',
+      }
+
+      const [saved] = await tx.insert(ticketUpdates).values(insertValues).returning()
+      if (!saved) {
+        throw new Error('Failed to create ticket update record')
+      }
+
+      const updateTicketValues: Partial<TicketInsert> = {
+        updatedAt: now,
+      }
+
+      if (data.status) {
+        updateTicketValues.status = data.status
+      }
+
+      if (data.actualCost !== undefined) {
+        updateTicketValues.actualCost = toPgNumeric(data.actualCost)
+      }
+
+      await tx.update(tickets).set(updateTicketValues).where(eq(tickets.id, ticketId))
+
+      return saved
+    })
+
+    if (data.notify) {
+      const statusLabel = createStatusLabel(data.status)
+      const messageParts = [`Status terkini tiket #${ticket.ticketNumber}: ${data.description}.`]
+      if (data.status) {
+        messageParts.push(`Status kini: ${statusLabel}.`)
+      }
+
+      await sendTicketWorkflowWhatsAppMessage({
+        customerId: ticket.customer.id,
+        ticketId,
+        phone: ticket.customer.phone,
+        stage: 'repair_update',
+        text: messageParts.join(' '),
+        metadata: {
+          updateId: record.id,
+          status: data.status ?? ticket.status,
+        },
+      })
+    }
+
+    return Response.json({ update: record })
+  } catch (error) {
+    logger.error({ err: error, ticketId }, 'Failed to create ticket update')
+    const message = error instanceof Error ? error.message : 'Unexpected error'
+    return Response.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/api/tickets/intake/route.ts
+++ b/app/api/tickets/intake/route.ts
@@ -1,0 +1,140 @@
+import { NextRequest } from 'next/server'
+import { eq } from 'drizzle-orm'
+import { z } from 'zod'
+
+import { db } from '@/db'
+import { customers, tickets } from '@/db/schema'
+import logger from '@/lib/logger'
+import { generateTicketNumber } from '@/lib/tickets'
+import { sendTicketWorkflowWhatsAppMessage } from '@/lib/wa-messaging'
+import { toPgNumeric } from '@/lib/pos'
+
+export const runtime = 'nodejs'
+
+const customerSchema = z.object({
+  name: z.string().min(2, 'Nama pelanggan diperlukan'),
+  phone: z.string().min(6, 'Nombor telefon diperlukan'),
+  email: z.string().email().optional().or(z.literal('').transform(() => undefined)),
+  company: z.string().optional().or(z.literal('').transform(() => undefined)),
+  notes: z.string().optional(),
+})
+
+const deviceSchema = z.object({
+  type: z.string().min(1, 'Jenis peranti diperlukan'),
+  model: z.string().min(1, 'Model peranti diperlukan'),
+  serialNumber: z.string().optional().or(z.literal('').transform(() => undefined)),
+})
+
+const intakeSchema = z.object({
+  customer: customerSchema,
+  device: deviceSchema,
+  problemDescription: z.string().min(10, 'Terangkan isu peranti'),
+  priority: z.enum(['low', 'normal', 'high', 'urgent']).default('normal'),
+  estimatedCost: z.number().nonnegative().optional(),
+})
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const payload = await request.json().catch(() => null)
+  const parsed = intakeSchema.safeParse(payload)
+
+  if (!parsed.success) {
+    return Response.json({ error: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const { customer: customerInput, device, problemDescription, priority, estimatedCost } = parsed.data
+
+  try {
+    const ticket = await db.transaction(async (tx) => {
+      const existingCustomer = await tx
+        .select()
+        .from(customers)
+        .where(eq(customers.phone, customerInput.phone))
+        .limit(1)
+        .then((rows) => rows[0])
+
+      const now = new Date()
+      const customerRecord = existingCustomer
+        ? (
+            await tx
+              .update(customers)
+              .set({
+                name: customerInput.name,
+                email: customerInput.email ?? existingCustomer.email,
+                company: customerInput.company ?? existingCustomer.company,
+                notes: customerInput.notes ?? existingCustomer.notes,
+                updatedAt: now,
+              })
+              .where(eq(customers.id, existingCustomer.id))
+              .returning()
+          )[0]
+        : (
+            await tx
+              .insert(customers)
+              .values({
+                name: customerInput.name,
+                phone: customerInput.phone,
+                email: customerInput.email,
+                company: customerInput.company,
+                notes: customerInput.notes,
+                createdAt: now,
+                updatedAt: now,
+              })
+              .returning()
+          )[0]
+
+      if (!customerRecord) {
+        throw new Error('Failed to persist customer record')
+      }
+
+      const ticketNumber = generateTicketNumber()
+
+      const [ticketRow] = await tx
+        .insert(tickets)
+        .values({
+          customerId: customerRecord.id,
+          ticketNumber,
+          deviceType: device.type,
+          deviceModel: device.model,
+          serialNumber: device.serialNumber ?? null,
+          problemDescription,
+          priority,
+          estimatedCost: estimatedCost !== undefined ? toPgNumeric(estimatedCost) : null,
+          status: 'pending',
+        })
+        .returning()
+
+      if (!ticketRow) {
+        throw new Error('Failed to create ticket record')
+      }
+
+      return {
+        ...ticketRow,
+        customer: customerRecord,
+      }
+    })
+
+    await sendTicketWorkflowWhatsAppMessage({
+      customerId: ticket.customer.id,
+      ticketId: ticket.id,
+      phone: ticket.customer.phone,
+      stage: 'intake_ack',
+      text: `Terima kasih ${ticket.customer.name}! Tiket servis #${ticket.ticketNumber} telah diterima. Kami akan jalankan diagnosis dan hubungi anda untuk langkah seterusnya.`,
+      metadata: {
+        priority,
+      },
+    })
+
+    return Response.json(
+      {
+        ticket: {
+          ...ticket,
+        },
+      },
+      { status: 201 },
+    )
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to process intake ticket')
+    const message = error instanceof Error ? error.message : 'Unexpected error'
+    return Response.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/intake/page.tsx
+++ b/app/intake/page.tsx
@@ -1,0 +1,295 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+
+const intakeFormSchema = z.object({
+  customerName: z.string().min(2, "Nama pelanggan diperlukan"),
+  customerPhone: z.string().min(6, "Nombor telefon diperlukan"),
+  customerEmail: z.string().email("Email tidak sah").optional().or(z.literal("").transform(() => undefined)),
+  customerCompany: z.string().optional(),
+  deviceType: z.string().min(2, "Jenis peranti diperlukan"),
+  deviceModel: z.string().min(2, "Model peranti diperlukan"),
+  serialNumber: z.string().optional(),
+  priority: z.enum(["low", "normal", "high", "urgent"]).default("normal"),
+  problemDescription: z.string().min(10, "Sila terangkan masalah peranti"),
+})
+
+type IntakeFormValues = z.infer<typeof intakeFormSchema>
+
+type ApiResponse = {
+  ticket?: {
+    id: string
+    ticketNumber: string
+    customer: {
+      name: string
+    }
+  }
+  error?: unknown
+}
+
+const priorities = [
+  { value: "low", label: "Rendah" },
+  { value: "normal", label: "Normal" },
+  { value: "high", label: "Tinggi" },
+  { value: "urgent", label: "Segera" },
+]
+
+export default function IntakePage() {
+  const router = useRouter()
+  const [submissionError, setSubmissionError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const form = useForm<IntakeFormValues>({
+    resolver: zodResolver(intakeFormSchema),
+    defaultValues: {
+      customerName: "",
+      customerPhone: "",
+      customerEmail: "",
+      customerCompany: "",
+      deviceType: "",
+      deviceModel: "",
+      serialNumber: "",
+      priority: "normal",
+      problemDescription: "",
+    },
+  })
+
+  const onSubmit = async (values: IntakeFormValues) => {
+    setSubmissionError(null)
+    setIsSubmitting(true)
+
+    try {
+      const response = await fetch("/api/tickets/intake", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          customer: {
+            name: values.customerName.trim(),
+            phone: values.customerPhone.trim(),
+            email: values.customerEmail?.trim() || undefined,
+            company: values.customerCompany?.trim() || undefined,
+          },
+          device: {
+            type: values.deviceType.trim(),
+            model: values.deviceModel.trim(),
+            serialNumber: values.serialNumber?.trim() || undefined,
+          },
+          priority: values.priority,
+          problemDescription: values.problemDescription.trim(),
+        }),
+      })
+
+      const payload = (await response.json().catch(() => ({}))) as ApiResponse
+
+      if (!response.ok || !payload.ticket) {
+        const errorMessage =
+          typeof payload.error === "string"
+            ? payload.error
+            : "Kami tidak dapat menghantar borang anda. Cuba lagi."
+        setSubmissionError(errorMessage)
+        return
+      }
+
+      form.reset()
+      router.push(`/intake/success?ticketNumber=${encodeURIComponent(payload.ticket.ticketNumber)}&name=${encodeURIComponent(payload.ticket.customer.name)}`)
+    } catch (error) {
+      console.error(error)
+      setSubmissionError("Ralat rangkaian. Sila cuba lagi.")
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col justify-center px-4 py-12">
+      <Card className="shadow-lg">
+        <CardHeader className="space-y-2">
+          <CardTitle className="text-2xl font-bold">Borang Pendaftaran Servis</CardTitle>
+          <CardDescription>
+            Berikan maklumat pelanggan dan peranti supaya kami boleh memulakan proses diagnosis dengan segera.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {submissionError ? (
+            <Alert variant="destructive" className="mb-6">
+              <AlertDescription>{submissionError}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="grid gap-6">
+              <div className="grid gap-4 md:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="customerName"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Nama pelanggan</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Contoh: Ahmad Ali" {...field} disabled={isSubmitting} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="customerPhone"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Nombor WhatsApp</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Contoh: +60123456789" {...field} disabled={isSubmitting} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="customerEmail"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Email (optional)</FormLabel>
+                      <FormControl>
+                        <Input type="email" placeholder="nama@contoh.com" {...field} disabled={isSubmitting} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="customerCompany"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Syarikat (optional)</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Nama syarikat" {...field} disabled={isSubmitting} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="deviceType"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Jenis peranti</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Contoh: Telefon, Laptop" {...field} disabled={isSubmitting} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="deviceModel"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Model peranti</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Contoh: iPhone 13 Pro" {...field} disabled={isSubmitting} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="serialNumber"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Nombor siri (optional)</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Masukkan nombor siri" {...field} disabled={isSubmitting} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="priority"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Keutamaan</FormLabel>
+                      <Select onValueChange={field.onChange} defaultValue={field.value} disabled={isSubmitting}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Pilih keutamaan" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {priorities.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <FormField
+                control={form.control}
+                name="problemDescription"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Penerangan masalah</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="Beritahu kami simptom, bila bermula, dan jika peranti pernah dibaiki sebelum ini."
+                        rows={5}
+                        {...field}
+                        disabled={isSubmitting}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="flex justify-end gap-3">
+                <Button type="button" variant="outline" disabled={isSubmitting} onClick={() => form.reset()}>
+                  Reset
+                </Button>
+                <Button type="submit" disabled={isSubmitting}>
+                  {isSubmitting ? "Menghantar..." : "Hantar tiket"}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/intake/success/page.tsx
+++ b/app/intake/success/page.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+
+interface SuccessPageProps {
+  searchParams?: Record<string, string | string[] | undefined>
+}
+
+function getParamValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0]
+  }
+  return value
+}
+
+export default function IntakeSuccessPage({ searchParams }: SuccessPageProps) {
+  const ticketNumber = getParamValue(searchParams?.ticketNumber)
+  const customerName = getParamValue(searchParams?.name)
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col justify-center px-4 py-16">
+      <Card className="shadow-lg">
+        <CardHeader className="space-y-3 text-center">
+          <CardTitle className="text-3xl font-semibold">Terima kasih!</CardTitle>
+          <CardDescription className="text-base">
+            {customerName ? `Hai ${customerName}, ` : ""}
+            permintaan servis anda telah diterima. Kami akan menghantar kemas kini melalui WhatsApp sebaik sahaja diagnosis siap.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 text-center">
+          {ticketNumber ? (
+            <div className="mx-auto max-w-md rounded-lg border border-dashed border-primary/40 bg-primary/5 px-4 py-6">
+              <p className="text-sm text-muted-foreground">Nombor tiket anda</p>
+              <p className="text-2xl font-bold tracking-wide text-primary">#{ticketNumber}</p>
+            </div>
+          ) : null}
+          <p className="text-muted-foreground">
+            Sila simpan nombor tiket ini untuk rujukan. Pasukan teknikal kami akan menghubungi anda dalam masa terdekat bagi
+            berkongsi hasil diagnosis, anggaran kos pembaikan dan langkah seterusnya.
+          </p>
+        </CardContent>
+        <CardFooter className="flex flex-col items-center gap-3">
+          <Button asChild size="lg">
+            <Link href="/">Kembali ke laman utama</Link>
+          </Button>
+          <p className="text-center text-sm text-muted-foreground">
+            Ada soalan segera? Hubungi kami melalui WhatsApp dan sebutkan nombor tiket anda supaya kami dapat membantu dengan
+            pantas.
+          </p>
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}

--- a/lib/tickets.ts
+++ b/lib/tickets.ts
@@ -1,0 +1,200 @@
+import { and, desc, eq, inArray } from 'drizzle-orm'
+import type { InferSelectModel } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { customers, diagnostics, invoices, quotes, ticketUpdates, tickets } from '@/db/schema'
+import logger from '@/lib/logger'
+import { formatDocumentNumber, toPgNumeric } from '@/lib/pos'
+
+export type TicketRecord = InferSelectModel<typeof tickets>
+export type CustomerRecord = InferSelectModel<typeof customers>
+export type DiagnosticRecord = InferSelectModel<typeof diagnostics>
+export type TicketUpdateRecord = InferSelectModel<typeof ticketUpdates>
+export type QuoteRecord = InferSelectModel<typeof quotes>
+export type InvoiceRecord = InferSelectModel<typeof invoices>
+
+export interface TicketWithRelations extends TicketRecord {
+  customer: CustomerRecord
+  latestDiagnostic: DiagnosticRecord | null
+  latestUpdate: TicketUpdateRecord | null
+  quote: QuoteRecord | null
+  invoice: InvoiceRecord | null
+}
+
+export const TICKET_NUMBER_PREFIX = 'TKT'
+
+export function generateTicketNumber(prefix = TICKET_NUMBER_PREFIX): string {
+  return formatDocumentNumber(prefix)
+}
+
+export async function getTicketById(id: string): Promise<TicketWithRelations | null> {
+  const [ticket] = await db
+    .select({ ticket: tickets, customer: customers })
+    .from(tickets)
+    .innerJoin(customers, eq(tickets.customerId, customers.id))
+    .where(eq(tickets.id, id))
+    .limit(1)
+
+  if (!ticket) {
+    return null
+  }
+
+  const [latestDiagnostic] = await db
+    .select()
+    .from(diagnostics)
+    .where(eq(diagnostics.ticketId, id))
+    .orderBy(desc(diagnostics.createdAt))
+    .limit(1)
+
+  const [latestUpdate] = await db
+    .select()
+    .from(ticketUpdates)
+    .where(eq(ticketUpdates.ticketId, id))
+    .orderBy(desc(ticketUpdates.createdAt))
+    .limit(1)
+
+  const [quote] = await db
+    .select()
+    .from(quotes)
+    .where(and(eq(quotes.ticketId, id), eq(quotes.status, 'sent')))
+    .orderBy(desc(quotes.createdAt))
+    .limit(1)
+
+  const [invoice] = await db
+    .select()
+    .from(invoices)
+    .where(eq(invoices.ticketId, id))
+    .orderBy(desc(invoices.createdAt))
+    .limit(1)
+
+  return {
+    ...ticket.ticket,
+    customer: ticket.customer,
+    latestDiagnostic: latestDiagnostic ?? null,
+    latestUpdate: latestUpdate ?? null,
+    quote: quote ?? null,
+    invoice: invoice ?? null,
+  }
+}
+
+export async function listTickets(limit = 30): Promise<TicketWithRelations[]> {
+  const rows = await db
+    .select({ ticket: tickets, customer: customers })
+    .from(tickets)
+    .innerJoin(customers, eq(tickets.customerId, customers.id))
+    .orderBy(desc(tickets.createdAt))
+    .limit(limit)
+
+  const ticketIds = rows.map((row) => row.ticket.id)
+
+  if (ticketIds.length === 0) {
+    return []
+  }
+
+  const diagnosticsByTicket = await db
+    .select()
+    .from(diagnostics)
+    .where(inArray(diagnostics.ticketId, ticketIds))
+    .orderBy(desc(diagnostics.createdAt))
+    .catch((error) => {
+      logger.error({ err: error }, 'Failed to load diagnostics for tickets')
+      return [] as DiagnosticRecord[]
+    })
+
+  const updatesByTicket = await db
+    .select()
+    .from(ticketUpdates)
+    .where(inArray(ticketUpdates.ticketId, ticketIds))
+    .orderBy(desc(ticketUpdates.createdAt))
+    .catch((error) => {
+      logger.error({ err: error }, 'Failed to load ticket updates')
+      return [] as TicketUpdateRecord[]
+    })
+
+  const quotesByTicket = await db
+    .select()
+    .from(quotes)
+    .where(inArray(quotes.ticketId, ticketIds))
+    .catch((error) => {
+      logger.error({ err: error }, 'Failed to load quotes for tickets')
+      return [] as QuoteRecord[]
+    })
+
+  const invoicesByTicket = await db
+    .select()
+    .from(invoices)
+    .where(inArray(invoices.ticketId, ticketIds))
+    .catch((error) => {
+      logger.error({ err: error }, 'Failed to load invoices for tickets')
+      return [] as InvoiceRecord[]
+    })
+
+  const diagnosticMap = new Map<string, DiagnosticRecord>()
+  for (const item of diagnosticsByTicket) {
+    if (!diagnosticMap.has(item.ticketId)) {
+      diagnosticMap.set(item.ticketId, item)
+    }
+  }
+
+  const updateMap = new Map<string, TicketUpdateRecord>()
+  for (const item of updatesByTicket) {
+    if (!updateMap.has(item.ticketId)) {
+      updateMap.set(item.ticketId, item)
+    }
+  }
+
+  const quoteMap = new Map<string, QuoteRecord>()
+  for (const item of quotesByTicket) {
+    const existing = quoteMap.get(item.ticketId)
+    const itemCreatedAt = item.createdAt instanceof Date ? item.createdAt.getTime() : new Date(item.createdAt ?? '').getTime()
+    const existingCreatedAt =
+      existing && existing.createdAt instanceof Date
+        ? existing.createdAt.getTime()
+        : new Date(existing?.createdAt ?? '').getTime()
+    if (!existing || itemCreatedAt > existingCreatedAt) {
+      quoteMap.set(item.ticketId, item)
+    }
+  }
+
+  const invoiceMap = new Map<string, InvoiceRecord>()
+  for (const item of invoicesByTicket) {
+    if (!invoiceMap.has(item.ticketId)) {
+      invoiceMap.set(item.ticketId, item)
+    }
+  }
+
+  return rows.map((row) => {
+    const ticketId = row.ticket.id
+    const latestDiagnostic = diagnosticMap.get(ticketId) ?? null
+    const latestUpdate = updateMap.get(ticketId) ?? null
+    const quote = quoteMap.get(ticketId) ?? null
+    const invoice = invoiceMap.get(ticketId) ?? null
+
+    return {
+      ...row.ticket,
+      customer: row.customer,
+      latestDiagnostic,
+      latestUpdate,
+      quote,
+      invoice,
+    }
+  })
+}
+
+export function upsertTicketEstimate(
+  ticketId: string,
+  estimate?: number | null,
+): Promise<void> {
+  if (estimate === undefined || estimate === null) {
+    return Promise.resolve()
+  }
+
+  return db
+    .update(tickets)
+    .set({
+      estimatedCost: toPgNumeric(estimate),
+      updatedAt: new Date(),
+    })
+    .where(eq(tickets.id, ticketId))
+    .then(() => undefined)
+}

--- a/lib/wa-messaging.ts
+++ b/lib/wa-messaging.ts
@@ -1,0 +1,77 @@
+import { db } from '@/db'
+import { waMessages } from '@/db/schema'
+import logger from '@/lib/logger'
+import { ensureWhatsAppJid, normalizePhoneNumber, sendWhatsAppTextMessage } from '@/lib/wa'
+
+export type TicketWorkflowStage =
+  | 'intake_ack'
+  | 'diagnosis_summary'
+  | 'diagnosis_approval'
+  | 'repair_update'
+  | 'pickup_ready'
+  | 'pickup_complete'
+
+export interface TicketWorkflowMessage {
+  customerId: string
+  ticketId: string
+  phone: string
+  text: string
+  stage: TicketWorkflowStage
+  metadata?: Record<string, unknown>
+}
+
+export async function sendTicketWorkflowWhatsAppMessage(payload: TicketWorkflowMessage): Promise<void> {
+  const normalized = normalizePhoneNumber(payload.phone)
+  if (!normalized) {
+    logger.warn({ customerId: payload.customerId }, 'Skipping WhatsApp send: invalid phone number')
+    return
+  }
+
+  const jid = ensureWhatsAppJid(normalized)
+  const sessionId = normalized.replace(/^\+/, '')
+  const sentAt = new Date()
+
+  const metadata = {
+    stage: payload.stage,
+    ticketId: payload.ticketId,
+    ...payload.metadata,
+  }
+
+  try {
+    await sendWhatsAppTextMessage({
+      to: jid,
+      text: payload.text,
+      metadata,
+    })
+
+    await db.insert(waMessages).values({
+      sessionId,
+      customerId: payload.customerId,
+      ticketId: payload.ticketId,
+      direction: 'outbound',
+      status: 'sent',
+      body: payload.text,
+      sentAt,
+      metadata: {
+        ...metadata,
+        normalizedRecipient: normalized,
+      },
+    })
+  } catch (error) {
+    logger.warn({ err: error, ticketId: payload.ticketId }, 'Failed to send ticket workflow WhatsApp message')
+    await db.insert(waMessages).values({
+      sessionId,
+      customerId: payload.customerId,
+      ticketId: payload.ticketId,
+      direction: 'outbound',
+      status: 'failed',
+      body: payload.text,
+      sentAt,
+      metadata: {
+        ...metadata,
+        normalizedRecipient: normalized,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- add public client intake flow with success screen and ticket creation API
- implement ticket lifecycle APIs with WhatsApp workflow messaging helpers
- build dashboard ticket and WhatsApp pages hooked to real data and quick actions; extend POS docs to link tickets on outbound messages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8e7a01244832bb4e0fd1ea120cc07