### PR TITLE
Ensure ticket updates track real users

### DIFF
--- a/db/auth-schema.ts
+++ b/db/auth-schema.ts
@@ -5,6 +5,8 @@ import {
   timestamp,
 } from 'drizzle-orm/pg-core';
 
+export const SYSTEM_USER_ID = 'system_service_user';
+
 export const user = pgTable('user', {
   id: text('id').primaryKey(),
   name: text('name').notNull(),

--- a/drizzle/0002_system_service_user.sql
+++ b/drizzle/0002_system_service_user.sql
@@ -1,0 +1,7 @@
+DO $$
+BEGIN
+  INSERT INTO "user" (id, name, email, email_verified, image, created_at, updated_at)
+  VALUES ('system_service_user', 'System Automation', 'system@local', true, NULL, NOW(), NOW())
+  ON CONFLICT (id) DO NOTHING;
+END $$;
+

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1759049562413,
       "tag": "0000_smooth_romulus",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1759049563413,
+      "tag": "0002_system_service_user",
+      "breakpoints": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- resolve ticket update authors via the current session, existing creator, or a seeded system service user and remove the string fallback
- seed a dedicated `system_service_user` account and record the migration in the Drizzle journal
- update dashboard ticket actions to include the authenticated operator id when sending update requests

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d905b1573c832b88b532a3dbb4b327