### PR TITLE
Implement stage-driven WhatsApp SOP handling

### DIFF
--- a/app/api/tickets/[id]/diagnose/route.ts
+++ b/app/api/tickets/[id]/diagnose/route.ts
@@ -120,7 +120,7 @@ export async function POST(
         customerId: ticket.customer.id,
         ticketId,
         phone: ticket.customer.phone,
-        stage: 'diagnosis_approval',
+        stage: 'awaiting_approval',
         text: data.approvalNotes ? `${approvalMessage} ${data.approvalNotes}` : approvalMessage,
         metadata: {
           approved: data.approved,

--- a/app/api/tickets/[id]/updates/route.ts
+++ b/app/api/tickets/[id]/updates/route.ts
@@ -177,7 +177,7 @@ export async function POST(
         customerId: ticket.customer.id,
         ticketId,
         phone: ticket.customer.phone,
-        stage: 'repair_update',
+        stage: 'repair_updates',
         text: messageParts.join(' '),
         metadata: {
           updateId: record.id,

--- a/app/api/whatsapp/webhook/route.ts
+++ b/app/api/whatsapp/webhook/route.ts
@@ -1,70 +1,217 @@
-import { NextRequest } from 'next/server';
-import { desc, eq, or } from 'drizzle-orm';
-import { z } from 'zod';
+import { NextRequest } from 'next/server'
+import { and, desc, eq, or } from 'drizzle-orm'
+import { z } from 'zod'
 
-import { db } from '@/db';
-import { customers, waMessages } from '@/db/schema';
-import logger from '@/lib/logger';
-import { coerceSopMetadata, evaluateSopTransition } from '@/lib/wa-sop';
-import { normalizePhoneNumber, sendWhatsAppTextMessage } from '@/lib/wa';
+import { db } from '@/db'
+import { customers, invoices, tickets, waMessages } from '@/db/schema'
+import logger from '@/lib/logger'
+import {
+  coerceSopMetadata,
+  detectSopCommand,
+  formatApprovalAcceptedMessage,
+  formatApprovalRejectedMessage,
+  formatInvoiceSummary,
+  formatNoTicketMessage,
+  formatPickupInstructions,
+  formatSupportHandoffMessage,
+  formatTicketStatusSummary,
+  formatUnknownCommandMessage,
+  formatCurrency,
+  stageFromTicketStatus,
+  type SopCommand,
+  type SopMetadata,
+  type SopStage,
+  type TicketStatus,
+} from '@/lib/wa-sop'
+import { sendTicketWorkflowWhatsAppMessage } from '@/lib/wa-messaging'
+import { normalizePhoneNumber, sendWhatsAppTextMessage } from '@/lib/wa'
 
-export const runtime = 'nodejs';
+export const runtime = 'nodejs'
 
 const inboundMessageSchema = z.object({
   from: z.string().min(1, 'Sender is required'),
   text: z.string().min(1, 'Message text is required'),
-});
+})
 
-type InsertWaMessage = typeof waMessages.$inferInsert;
-type SopMetadata = ReturnType<typeof coerceSopMetadata>;
+type InsertWaMessage = typeof waMessages.$inferInsert
 
-type RawMetadata = Record<string, unknown> | null | undefined;
+type RawMetadata = Record<string, unknown> | null | undefined
 
-function extractSopMetadata(metadata: RawMetadata): SopMetadata {
-  if (metadata && typeof metadata === 'object' && 'sop' in metadata) {
-    return coerceSopMetadata((metadata as Record<string, unknown>).sop);
-  }
-
-  return coerceSopMetadata(metadata);
+type CustomerRecord = {
+  id: string
+  name: string | null
+  phone: string
 }
 
-async function findCustomerIdByPhone(msisdn: string): Promise<string | null> {
+interface TicketContext {
+  id: string
+  ticketNumber: string
+  status: TicketStatus
+  customerId: string
+  customerName: string | null
+  customerPhone: string
+  estimatedCost: string | null
+  invoice: {
+    id: string
+    number: string
+    total: string | null
+    status: string | null
+  } | null
+}
+
+function extractSopMetadata(metadata: RawMetadata): SopMetadata {
+  return coerceSopMetadata(metadata ?? null)
+}
+
+async function findCustomerByPhone(msisdn: string): Promise<CustomerRecord | null> {
   if (!msisdn) {
-    return null;
+    return null
   }
 
-  const plain = msisdn.replace(/^\+/, '');
+  const plain = msisdn.replace(/^\+/, '')
   const [record] = await db
-    .select({ id: customers.id })
+    .select({ id: customers.id, name: customers.name, phone: customers.phone })
     .from(customers)
     .where(or(eq(customers.phone, msisdn), eq(customers.phone, plain)))
-    .limit(1);
+    .limit(1)
 
-  return record?.id ?? null;
+  return record ?? null
+}
+
+async function getTicketContextById(ticketId: string): Promise<TicketContext | null> {
+  const [record] = await db
+    .select({
+      id: tickets.id,
+      ticketNumber: tickets.ticketNumber,
+      status: tickets.status,
+      customerId: tickets.customerId,
+      customerName: customers.name,
+      customerPhone: customers.phone,
+      estimatedCost: tickets.estimatedCost,
+    })
+    .from(tickets)
+    .innerJoin(customers, eq(customers.id, tickets.customerId))
+    .where(eq(tickets.id, ticketId))
+    .limit(1)
+
+  if (!record) {
+    return null
+  }
+
+  const [invoiceRecord] = await db
+    .select({
+      id: invoices.id,
+      number: invoices.number,
+      total: invoices.total,
+      status: invoices.status,
+    })
+    .from(invoices)
+    .where(eq(invoices.ticketId, ticketId))
+    .orderBy(desc(invoices.createdAt))
+    .limit(1)
+
+  return {
+    id: record.id,
+    ticketNumber: record.ticketNumber,
+    status: record.status as TicketStatus,
+    customerId: record.customerId,
+    customerName: record.customerName,
+    customerPhone: record.customerPhone,
+    estimatedCost: record.estimatedCost ?? null,
+    invoice: invoiceRecord
+      ? {
+          id: invoiceRecord.id,
+          number: invoiceRecord.number,
+          total: invoiceRecord.total ?? null,
+          status: invoiceRecord.status ?? null,
+        }
+      : null,
+  }
+}
+
+async function findLatestTicketForCustomer(customerId: string): Promise<TicketContext | null> {
+  const [record] = await db
+    .select({ id: tickets.id })
+    .from(tickets)
+    .where(eq(tickets.customerId, customerId))
+    .orderBy(desc(tickets.updatedAt), desc(tickets.createdAt))
+    .limit(1)
+
+  if (!record) {
+    return null
+  }
+
+  return getTicketContextById(record.id)
+}
+
+async function findLatestTicketByStatus(
+  customerId: string,
+  status: TicketStatus,
+): Promise<TicketContext | null> {
+  const [record] = await db
+    .select({ id: tickets.id })
+    .from(tickets)
+    .where(and(eq(tickets.customerId, customerId), eq(tickets.status, status)))
+    .orderBy(desc(tickets.updatedAt), desc(tickets.createdAt))
+    .limit(1)
+
+  if (!record) {
+    return null
+  }
+
+  return getTicketContextById(record.id)
+}
+
+async function resolveTicketContext(
+  customerId: string | null,
+  previous: SopMetadata,
+  command: SopCommand,
+): Promise<TicketContext | null> {
+  if (!customerId) {
+    return null
+  }
+
+  if (previous.ticketId) {
+    const ticket = await getTicketContextById(previous.ticketId)
+    if (ticket) {
+      if ((command === 'approve' || command === 'reject') && ticket.status !== 'awaiting_approval') {
+        // Continue searching for awaiting approval ticket below
+      } else {
+        return ticket
+      }
+    }
+  }
+
+  if (command === 'approve' || command === 'reject') {
+    const awaiting = await findLatestTicketByStatus(customerId, 'awaiting_approval')
+    if (awaiting) {
+      return awaiting
+    }
+  }
+
+  return findLatestTicketForCustomer(customerId)
 }
 
 async function insertWaMessage(values: InsertWaMessage): Promise<typeof waMessages.$inferSelect | null> {
-  const [record] = await db.insert(waMessages).values(values).returning();
-  return record ?? null;
+  const [record] = await db.insert(waMessages).values(values).returning()
+  return record ?? null
 }
 
 export async function POST(request: NextRequest): Promise<Response> {
-  const payload = await request
-    .json()
-    .catch(() => null);
+  const payload = await request.json().catch(() => null)
 
-  const parsed = inboundMessageSchema.safeParse(payload);
+  const parsed = inboundMessageSchema.safeParse(payload)
   if (!parsed.success) {
-    return Response.json({ error: 'Invalid webhook payload' }, { status: 400 });
+    return Response.json({ error: 'Invalid webhook payload' }, { status: 400 })
   }
 
-  const { from, text } = parsed.data;
-  const normalizedFrom = normalizePhoneNumber(from);
+  const { from, text } = parsed.data
+  const normalizedFrom = normalizePhoneNumber(from)
   if (!normalizedFrom) {
-    return Response.json({ error: 'Invalid sender phone number' }, { status: 400 });
+    return Response.json({ error: 'Invalid sender phone number' }, { status: 400 })
   }
 
-  const sessionId = normalizedFrom.replace(/^\+/, '');
+  const sessionId = normalizedFrom.replace(/^\+/, '')
 
   try {
     const [previousMessage] = await db
@@ -72,92 +219,276 @@ export async function POST(request: NextRequest): Promise<Response> {
       .from(waMessages)
       .where(eq(waMessages.sessionId, sessionId))
       .orderBy(desc(waMessages.createdAt))
-      .limit(1);
+      .limit(1)
 
-    const previousSop = extractSopMetadata(previousMessage?.metadata as RawMetadata);
+    const previousSop = extractSopMetadata(previousMessage?.metadata as RawMetadata)
+    const command = detectSopCommand(text)
 
-    const transition = evaluateSopTransition({
-      previousState: previousSop.state,
-      previousIntent: previousSop.intent,
-      inboundText: text,
-    });
+    const customer = await findCustomerByPhone(normalizedFrom)
+    let ticket = await resolveTicketContext(customer?.id ?? null, previousSop, command)
 
-    const customerId = await findCustomerIdByPhone(normalizedFrom);
+    const now = new Date()
+
+    let responseMode: 'workflow' | 'text' | 'none' = 'none'
+    let responseStage: SopStage | null = null
+    let responseText: string | null = null
+    let nextTicketStatus: TicketStatus | null = ticket?.status ?? previousSop.ticketStatus ?? null
+    const ticketIdForMetadata: string | null = ticket?.id ?? previousSop.ticketId ?? null
+
+    switch (command) {
+      case 'approve':
+        if (!ticket) {
+          responseMode = 'text'
+          responseText = formatNoTicketMessage()
+          responseStage = previousSop.stage
+          break
+        }
+
+        if (ticket.status !== 'awaiting_approval') {
+          const summary = formatTicketStatusSummary({
+            ticketNumber: ticket.ticketNumber,
+            status: ticket.status,
+            customerName: customer?.name ?? ticket.customerName,
+          })
+          responseMode = 'workflow'
+          responseStage = summary.stage
+          responseText = summary.text
+          nextTicketStatus = ticket.status
+          break
+        }
+
+        await db
+          .update(tickets)
+          .set({ status: 'approved', updatedAt: now })
+          .where(eq(tickets.id, ticket.id))
+
+        ticket = { ...ticket, status: 'approved' }
+        nextTicketStatus = 'approved'
+        responseMode = 'workflow'
+        responseStage = 'awaiting_approval'
+        responseText = formatApprovalAcceptedMessage({
+          ticketNumber: ticket.ticketNumber,
+          customerName: customer?.name ?? ticket.customerName,
+          estimatedCost: formatCurrency(ticket.estimatedCost),
+        })
+        break
+      case 'reject':
+        if (!ticket) {
+          responseMode = 'text'
+          responseText = formatNoTicketMessage()
+          responseStage = previousSop.stage
+          break
+        }
+
+        if (ticket.status !== 'awaiting_approval') {
+          const summary = formatTicketStatusSummary({
+            ticketNumber: ticket.ticketNumber,
+            status: ticket.status,
+            customerName: customer?.name ?? ticket.customerName,
+          })
+          responseMode = 'workflow'
+          responseStage = summary.stage
+          responseText = summary.text
+          nextTicketStatus = ticket.status
+          break
+        }
+
+        await db
+          .update(tickets)
+          .set({ status: 'rejected', updatedAt: now })
+          .where(eq(tickets.id, ticket.id))
+
+        ticket = { ...ticket, status: 'rejected' }
+        nextTicketStatus = 'rejected'
+        responseMode = 'workflow'
+        responseStage = 'awaiting_approval'
+        responseText = formatApprovalRejectedMessage({
+          ticketNumber: ticket.ticketNumber,
+          customerName: customer?.name ?? ticket.customerName,
+        })
+        break
+      case 'status':
+        if (!ticket) {
+          responseMode = 'text'
+          responseText = formatNoTicketMessage()
+          responseStage = previousSop.stage
+          break
+        }
+
+        {
+          const summary = formatTicketStatusSummary({
+            ticketNumber: ticket.ticketNumber,
+            status: ticket.status,
+            customerName: customer?.name ?? ticket.customerName,
+          })
+          responseMode = 'workflow'
+          responseStage = summary.stage
+          responseText = summary.text
+          nextTicketStatus = ticket.status
+        }
+        break
+      case 'invoice':
+        if (!ticket) {
+          responseMode = 'text'
+          responseText = formatNoTicketMessage()
+          responseStage = previousSop.stage
+          break
+        }
+
+        {
+          const invoice = formatInvoiceSummary({
+            ticketNumber: ticket.ticketNumber,
+            invoiceNumber: ticket.invoice?.number ?? null,
+            invoiceTotal: formatCurrency(ticket.invoice?.total ?? null),
+            invoiceStatus: ticket.invoice?.status ?? null,
+          })
+          responseMode = 'workflow'
+          responseStage = invoice.stage
+          responseText = invoice.text
+          nextTicketStatus = ticket.status
+        }
+        break
+      case 'pickup':
+        if (!ticket) {
+          responseMode = 'text'
+          responseText = formatNoTicketMessage()
+          responseStage = previousSop.stage
+          break
+        }
+
+        {
+          const pickup = formatPickupInstructions({
+            ticketNumber: ticket.ticketNumber,
+            status: ticket.status,
+            customerName: customer?.name ?? ticket.customerName,
+            invoiceStatus: ticket.invoice?.status ?? null,
+            invoiceTotal: formatCurrency(ticket.invoice?.total ?? null),
+          })
+          responseMode = 'workflow'
+          responseStage = pickup.stage
+          responseText = pickup.text
+          nextTicketStatus = ticket.status
+        }
+        break
+      case 'support':
+        responseMode = 'text'
+        responseStage = ticket ? stageFromTicketStatus(ticket.status) : previousSop.stage
+        responseText = formatSupportHandoffMessage(customer?.name ?? ticket?.customerName ?? null)
+        nextTicketStatus = ticket?.status ?? nextTicketStatus
+        break
+      default:
+        responseText = formatUnknownCommandMessage()
+        if (ticket) {
+          responseMode = 'workflow'
+          responseStage = stageFromTicketStatus(ticket.status)
+          nextTicketStatus = ticket.status
+        } else {
+          responseMode = 'text'
+          responseStage = previousSop.stage
+        }
+        break
+    }
+
+    if (responseStage === null) {
+      responseStage = ticket ? stageFromTicketStatus(nextTicketStatus ?? ticket.status) : previousSop.stage
+    }
+
+    const sessionStage = responseStage ?? previousSop.stage ?? null
+    const sessionTicketStatus = nextTicketStatus ?? previousSop.ticketStatus ?? null
+    const sessionTicketId = ticketIdForMetadata ?? ticket?.id ?? previousSop.ticketId ?? null
+
+    const sessionState: SopMetadata = {
+      stage: sessionStage,
+      ticketId: sessionTicketId,
+      lastCommand: command === 'unknown' ? previousSop.lastCommand : command,
+      ticketStatus: sessionTicketStatus,
+    }
 
     const inboundRecord = await insertWaMessage({
       sessionId,
-      customerId,
+      customerId: customer?.id ?? null,
+      ticketId: sessionTicketId,
       direction: 'in',
       status: 'received',
       body: text,
-      sentAt: new Date(),
+      sentAt: now,
       metadata: {
         from,
         normalizedFrom,
-        sop: {
-          state: previousSop.state,
-          intent: transition.intent ?? previousSop.intent ?? null,
-          reference: transition.reference ?? previousSop.reference ?? null,
-        },
+        command,
+        sop: sessionState,
       },
-    });
+    })
 
-    try {
-      await sendWhatsAppTextMessage({
-        to: normalizedFrom,
-        text: transition.reply,
+    if (responseMode === 'workflow' && responseText && ticket && customer) {
+      const stageToSend: SopStage = responseStage ?? stageFromTicketStatus(ticket.status)
+
+      await sendTicketWorkflowWhatsAppMessage({
+        customerId: customer.id,
+        ticketId: ticket.id,
+        phone: normalizedFrom,
+        stage: stageToSend,
+        text: responseText,
         metadata: {
+          command,
+          respondsTo: inboundRecord?.id ?? null,
+          sop: sessionState,
+        },
+      })
+    } else if (responseMode === 'text' && responseText) {
+      try {
+        await sendWhatsAppTextMessage({
+          to: normalizedFrom,
+          text: responseText,
+          metadata: {
+            sessionId,
+            source: 'sop-automation',
+            command,
+            sop: sessionState,
+            inboundMessageId: inboundRecord?.id ?? null,
+          },
+        })
+
+        await insertWaMessage({
           sessionId,
-          source: 'sop-automation',
-          intent: transition.intent ?? previousSop.intent ?? null,
-          reference: transition.reference ?? previousSop.reference ?? null,
-          inboundMessageId: inboundRecord?.id ?? null,
-        },
-      });
-
-      await insertWaMessage({
-        sessionId,
-        customerId,
-        direction: 'out',
-        status: 'sent',
-        body: transition.reply,
-        sentAt: new Date(),
-        metadata: {
-          normalizedFrom,
-          respondsTo: inboundRecord?.id ?? null,
-          sop: {
-            state: transition.nextState,
-            intent: transition.intent ?? previousSop.intent ?? null,
-            reference: transition.reference ?? previousSop.reference ?? null,
+          customerId: customer?.id ?? null,
+          ticketId: sessionTicketId,
+          direction: 'out',
+          status: 'sent',
+          body: responseText,
+          sentAt: now,
+          metadata: {
+            normalizedFrom,
+            respondsTo: inboundRecord?.id ?? null,
+            command,
+            sop: sessionState,
           },
-        },
-      });
-    } catch (error) {
-      logger.error({ err: error }, 'Failed to send SOP reply');
+        })
+      } catch (error) {
+        logger.error({ err: error }, 'Failed to send SOP reply')
 
-      await insertWaMessage({
-        sessionId,
-        customerId,
-        direction: 'out',
-        status: 'failed',
-        body: transition.reply,
-        sentAt: new Date(),
-        metadata: {
-          normalizedFrom,
-          respondsTo: inboundRecord?.id ?? null,
-          error: error instanceof Error ? error.message : 'Unknown error',
-          sop: {
-            state: transition.nextState,
-            intent: transition.intent ?? previousSop.intent ?? null,
-            reference: transition.reference ?? previousSop.reference ?? null,
+        await insertWaMessage({
+          sessionId,
+          customerId: customer?.id ?? null,
+          ticketId: sessionTicketId,
+          direction: 'out',
+          status: 'failed',
+          body: responseText,
+          sentAt: now,
+          metadata: {
+            normalizedFrom,
+            respondsTo: inboundRecord?.id ?? null,
+            command,
+            sop: sessionState,
+            error: error instanceof Error ? error.message : 'Unknown error',
           },
-        },
-      });
+        })
+      }
     }
 
-    return Response.json({ success: true });
+    return Response.json({ success: true })
   } catch (error) {
-    logger.error({ err: error }, 'Failed to process WhatsApp webhook');
-    return Response.json({ error: 'Failed to process webhook' }, { status: 500 });
+    logger.error({ err: error }, 'Failed to process WhatsApp webhook')
+    return Response.json({ error: 'Failed to process webhook' }, { status: 500 })
   }
 }

--- a/lib/scheduler.ts
+++ b/lib/scheduler.ts
@@ -12,7 +12,7 @@ import type { TicketWorkflowStage } from '@/lib/wa-messaging'
 import { normalizePhoneNumber } from '@/lib/wa'
 
 const REMINDER_CONTEXT = 'ticket_awaiting_approval'
-const REMINDER_STAGE: TicketWorkflowStage = 'diagnosis_approval'
+const REMINDER_STAGE: TicketWorkflowStage = 'awaiting_approval'
 
 const REMINDER_BUCKETS = [
   { days: 1 },

--- a/lib/wa-sop.ts
+++ b/lib/wa-sop.ts
@@ -1,204 +1,402 @@
-import { z } from 'zod';
+import { z } from 'zod'
 
-export type SopState =
-  | 'new'
-  | 'awaiting_intent'
-  | 'awaiting_reference'
-  | 'completed';
+export const SOP_STAGE_VALUES = [
+  'intake_ack',
+  'diagnosis_summary',
+  'awaiting_approval',
+  'repair_updates',
+  'done_invoice',
+  'pickup_ready',
+  'pickup_complete',
+  'review_reminder',
+] as const
 
-export type SopIntent = 'status' | 'quotation' | 'invoice' | 'handoff';
+const SOP_STAGE_ALIASES = ['diagnosis_approval', 'repair_update'] as const
+
+export type SopStage = (typeof SOP_STAGE_VALUES)[number]
+
+export const TICKET_STATUS_VALUES = [
+  'intake',
+  'diagnosed',
+  'awaiting_approval',
+  'approved',
+  'rejected',
+  'repairing',
+  'done',
+  'picked_up',
+] as const
+
+export type TicketStatus = (typeof TICKET_STATUS_VALUES)[number]
+
+const SOP_COMMAND_VALUES = ['status', 'invoice', 'pickup', 'support', 'approve', 'reject'] as const
+
+export type SopCommand = (typeof SOP_COMMAND_VALUES)[number] | 'unknown'
 
 export interface SopMetadata {
-  state: SopState;
-  intent?: SopIntent | null;
-  reference?: string | null;
+  stage: SopStage | null
+  ticketId: string | null
+  lastCommand: SopCommand | null
+  ticketStatus: TicketStatus | null
 }
 
-export const SOP_METADATA_SCHEMA = z
-  .object({
-    state: z.enum(['new', 'awaiting_intent', 'awaiting_reference', 'completed']).default('new'),
-    intent: z.enum(['status', 'quotation', 'invoice', 'handoff']).optional().nullable(),
-    reference: z.string().optional().nullable(),
-  })
-  .partial({ intent: true, reference: true });
+export const SOP_METADATA_SCHEMA = z.object({
+  stage: z.enum([...SOP_STAGE_VALUES, ...SOP_STAGE_ALIASES]).nullable().optional(),
+  ticketId: z.string().uuid().nullable().optional(),
+  lastCommand: z.enum(SOP_COMMAND_VALUES).nullable().optional(),
+  ticketStatus: z.enum(TICKET_STATUS_VALUES).nullable().optional(),
+})
 
-const WELCOME_MESSAGE = [
-  'Hai! 👋 Selamat datang ke WhatsApp POS System kami.',
-  'Bagaimana kami boleh bantu anda hari ini?',
-  '',
-  'Balas dengan pilihan berikut:',
-  '1 - Semak status pembaikan',
-  '2 - Minta salinan quotation',
-  '3 - Minta salinan invois',
-  '4 - Bercakap dengan staf kami',
-].join('\n');
-
-const UNKNOWN_INTENT_MESSAGE = [
-  'Maaf, kami tidak pasti permintaan anda.',
-  'Sila balas dengan nombor pilihan yang sesuai (1-4) atau jelaskan sama ada anda perlukan status, quotation, invois, atau ingin bercakap dengan staf.',
-].join(' ');
-
-const HANDOFF_MESSAGE =
-  'Baik, kami akan maklumkan pasukan sokongan kami untuk hubungi anda secepat mungkin. Terima kasih atas kesabaran anda!';
-
-const referencePrompts: Record<Exclude<SopIntent, 'handoff'>, string> = {
-  status: 'Baik! Untuk semak status, sila berikan nombor tiket atau nombor telefon yang digunakan semasa check-in.',
-  quotation: 'Baik! Untuk semak quotation, sila berikan nombor tiket, nombor quotation, atau nombor telefon pelanggan.',
-  invoice: 'Baik! Untuk semak invois, sila berikan nombor invois atau nombor telefon pelanggan.',
-};
-
-const referenceFollowups: Record<Exclude<SopIntent, 'handoff'>, string> = {
-  status: 'Kami perlukan nombor tiket atau nombor telefon untuk semak status. Sila cuba berikan rujukan yang sah.',
-  quotation: 'Untuk bantu dengan quotation, kami perlukan nombor rujukan seperti nombor tiket, quotation atau nombor telefon.',
-  invoice: 'Untuk cari invois yang betul, kami perlukan nombor invois atau nombor telefon pelanggan. Boleh cuba sekali lagi?',
-};
-
-function detectIntent(message: string): SopIntent | null {
-  const normalized = message.toLowerCase();
-
-  if (/(^|\s)(1|status|progress|baik pulih|repair|pembaikan)(\s|$)/.test(normalized)) {
-    return 'status';
-  }
-  if (/(^|\s)(2|quote|quotation|sebutharga|sebut harga)(\s|$)/.test(normalized)) {
-    return 'quotation';
-  }
-  if (/(^|\s)(3|invoice|invois|bill|bayar|bayaran|payment)(\s|$)/.test(normalized)) {
-    return 'invoice';
-  }
-  if (/(^|\s)(4|manusia|human|agent|staf|staff|pegawai|hubungi)(\s|$)/.test(normalized)) {
-    return 'handoff';
+function normalizeStage(value: string | null | undefined): SopStage | null {
+  if (!value) {
+    return null
   }
 
-  return null;
+  if ((SOP_STAGE_VALUES as readonly string[]).includes(value as SopStage)) {
+    return value as SopStage
+  }
+
+  if (value === 'diagnosis_approval') {
+    return 'awaiting_approval'
+  }
+
+  if (value === 'repair_update') {
+    return 'repair_updates'
+  }
+
+  return null
 }
 
-function sanitizeReference(message: string): string | null {
-  const trimmed = message.trim();
-  if (!trimmed) {
-    return null;
+function normalizeTicketStatus(value: string | null | undefined): TicketStatus | null {
+  if (!value) {
+    return null
   }
 
-  const condensed = trimmed.replace(/\s+/g, ' ');
-  if (condensed.length < 3) {
-    return null;
+  return (TICKET_STATUS_VALUES as readonly string[]).includes(value as TicketStatus)
+    ? (value as TicketStatus)
+    : null
+}
+
+function normalizeCommand(value: string | null | undefined): SopCommand | null {
+  if (!value) {
+    return null
   }
 
-  return condensed;
-}
-
-function acknowledgement(intent: Exclude<SopIntent, 'handoff'>, reference: string): string {
-  switch (intent) {
-    case 'status':
-      return `Terima kasih! Kami akan semak status untuk rujukan "${reference}" dan hubungi anda semula dalam masa terdekat.`;
-    case 'quotation':
-      return `Terima kasih! Kami akan semak quotation untuk rujukan "${reference}" dan maklumkan anda secepat mungkin.`;
-    case 'invoice':
-      return `Terima kasih! Kami akan semak invois untuk rujukan "${reference}" dan kembali kepada anda sebentar lagi.`;
-    default:
-      return 'Terima kasih! Kami akan menyemak maklumat tersebut segera.';
-  }
-}
-
-export interface SopTransitionInput {
-  previousState: SopState;
-  previousIntent?: SopIntent | null;
-  inboundText: string;
-}
-
-export interface SopTransitionResult {
-  reply: string;
-  nextState: SopState;
-  intent?: SopIntent | null;
-  reference?: string | null;
-}
-
-export function evaluateSopTransition(input: SopTransitionInput): SopTransitionResult {
-  const baseState = input.previousState === 'completed' ? 'new' : input.previousState;
-  const text = input.inboundText ?? '';
-
-  switch (baseState) {
-    case 'new':
-      return {
-        reply: WELCOME_MESSAGE,
-        nextState: 'awaiting_intent',
-        intent: null,
-        reference: null,
-      };
-    case 'awaiting_intent': {
-      const intent = detectIntent(text);
-      if (!intent) {
-        return {
-          reply: UNKNOWN_INTENT_MESSAGE,
-          nextState: 'awaiting_intent',
-          intent: input.previousIntent ?? null,
-          reference: null,
-        };
-      }
-
-      if (intent === 'handoff') {
-        return {
-          reply: HANDOFF_MESSAGE,
-          nextState: 'completed',
-          intent,
-          reference: null,
-        };
-      }
-
-      return {
-        reply: referencePrompts[intent],
-        nextState: 'awaiting_reference',
-        intent,
-        reference: null,
-      };
-    }
-    case 'awaiting_reference': {
-      const intent = input.previousIntent ?? detectIntent(text) ?? null;
-      if (!intent || intent === 'handoff') {
-        return {
-          reply: UNKNOWN_INTENT_MESSAGE,
-          nextState: 'awaiting_intent',
-          intent: null,
-          reference: null,
-        };
-      }
-
-      const reference = sanitizeReference(text);
-      if (!reference) {
-        return {
-          reply: referenceFollowups[intent],
-          nextState: 'awaiting_reference',
-          intent,
-          reference: null,
-        };
-      }
-
-      return {
-        reply: acknowledgement(intent, reference),
-        nextState: 'completed',
-        intent,
-        reference,
-      };
-    }
-    case 'completed':
-    default:
-      return {
-        reply: WELCOME_MESSAGE,
-        nextState: 'awaiting_intent',
-        intent: null,
-        reference: null,
-      };
-  }
+  return (SOP_COMMAND_VALUES as readonly string[]).includes(value as SopCommand)
+    ? (value as SopCommand)
+    : null
 }
 
 export function coerceSopMetadata(value: unknown): SopMetadata {
-  const parsed = SOP_METADATA_SCHEMA.safeParse(value);
+  const base: SopMetadata = {
+    stage: null,
+    ticketId: null,
+    lastCommand: null,
+    ticketStatus: null,
+  }
+
+  if (!value || typeof value !== 'object') {
+    return base
+  }
+
+  const container = 'sop' in (value as Record<string, unknown>) ? (value as Record<string, unknown>).sop : value
+  const parsed = SOP_METADATA_SCHEMA.safeParse(container)
+
   if (!parsed.success) {
-    return { state: 'new', intent: null, reference: null };
+    return base
   }
 
   return {
-    state: parsed.data.state ?? 'new',
-    intent: parsed.data.intent ?? null,
-    reference: parsed.data.reference ?? null,
-  };
+    stage: normalizeStage(parsed.data.stage ?? null),
+    ticketId: parsed.data.ticketId ?? null,
+    lastCommand: normalizeCommand(parsed.data.lastCommand ?? null),
+    ticketStatus: normalizeTicketStatus(parsed.data.ticketStatus ?? null),
+  }
+}
+
+const APPROVE_REGEX = /(setuju|approve|lulus|ya|yes|ok)(?!\w)/i
+const REJECT_REGEX = /(tak\s*setuju|tidak\s*setuju|tolak|reject|no)(?!\w)/i
+const STATUS_REGEX = /(^|\b)(1|status|progress|kemajuan|update)(\b|$)/i
+const INVOICE_REGEX = /(^|\b)(2|invoice|invois|resit|bill|bayar|bayaran|payment)(\b|$)/i
+const PICKUP_REGEX = /(^|\b)(3|pickup|ambik|ambil|collect|pengambilan)(\b|$)/i
+const SUPPORT_REGEX = /(^|\b)(4|staf|staff|manusia|agent|bantuan|tolong|hubungi)(\b|$)/i
+
+export function detectSopCommand(message: string): SopCommand {
+  const normalized = message?.trim().toLowerCase() ?? ''
+  if (!normalized) {
+    return 'unknown'
+  }
+
+  if (REJECT_REGEX.test(normalized)) {
+    return 'reject'
+  }
+
+  if (APPROVE_REGEX.test(normalized)) {
+    return 'approve'
+  }
+
+  if (PICKUP_REGEX.test(normalized)) {
+    return 'pickup'
+  }
+
+  if (INVOICE_REGEX.test(normalized)) {
+    return 'invoice'
+  }
+
+  if (STATUS_REGEX.test(normalized)) {
+    return 'status'
+  }
+
+  if (SUPPORT_REGEX.test(normalized)) {
+    return 'support'
+  }
+
+  return 'unknown'
+}
+
+const MENU_FOOTER =
+  '📲 Pilihan pantas: balas 1 = Status semasa, 2 = Salinan invois, 3 = Arahan pickup. Untuk kelulusan, balas "setuju" atau "tak setuju". Perlu bantuan manusia? Balas 4.'
+
+export function formatMenuFooter(): string {
+  return MENU_FOOTER
+}
+
+const currencyFormatter = new Intl.NumberFormat('ms-MY', {
+  style: 'currency',
+  currency: 'MYR',
+})
+
+export function formatCurrency(value: string | number | null | undefined): string | null {
+  if (value === null || value === undefined) {
+    return null
+  }
+
+  const numeric = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(numeric)) {
+    return null
+  }
+
+  return currencyFormatter.format(numeric)
+}
+
+export interface TicketStatusSummaryContext {
+  ticketNumber: string
+  status: TicketStatus
+  customerName?: string | null
+}
+
+export interface TicketStatusSummaryResult {
+  stage: SopStage
+  text: string
+}
+
+export function formatTicketStatusSummary(context: TicketStatusSummaryContext): TicketStatusSummaryResult {
+  const ticketLabel = `tiket #${context.ticketNumber}`
+  const name = context.customerName?.trim()
+  const greeting = name ? `${name}, ` : ''
+
+  let stage: SopStage = 'intake_ack'
+  let message: string
+
+  switch (context.status) {
+    case 'intake':
+      stage = 'intake_ack'
+      message = `${greeting}${ticketLabel} telah diterima dan kami sedang menjadualkan diagnosis awal.`
+      break
+    case 'diagnosed':
+      stage = 'diagnosis_summary'
+      message = `${greeting}pasukan teknikal kami sedang menyiapkan ringkasan diagnosis untuk ${ticketLabel}. Anda akan menerima butiran sekejap lagi.`
+      break
+    case 'awaiting_approval':
+      stage = 'awaiting_approval'
+      message = `${greeting}kami sedang menunggu kelulusan anda untuk ${ticketLabel}. Balas "setuju" untuk teruskan atau "tak setuju" jika mahu menangguhkan.`
+      break
+    case 'approved':
+      stage = 'repair_updates'
+      message = `${greeting}kelulusan bagi ${ticketLabel} diterima. Kami sedang menempah alat ganti dan akan berkongsi kemas kini pembaikan.`
+      break
+    case 'repairing':
+      stage = 'repair_updates'
+      message = `${greeting}pembaikan untuk ${ticketLabel} sedang dijalankan. Kami akan maklumkan sebarang kemajuan penting.`
+      break
+    case 'done':
+      stage = 'done_invoice'
+      message = `${greeting}${ticketLabel} telah siap dan invois tersedia untuk semakan. Balas 3 jika anda perlukan arahan pengambilan.`
+      break
+    case 'picked_up':
+      stage = 'pickup_complete'
+      message = `${greeting}${ticketLabel} telah diambil. Terima kasih kerana mempercayai kami! Kongsikan maklum balas anda bila-bila masa.`
+      break
+    case 'rejected':
+      stage = 'awaiting_approval'
+      message = `${greeting}permintaan pembaikan untuk ${ticketLabel} telah dihentikan mengikut arahan anda. Hubungi kami jika mahu membuat perubahan.`
+      break
+    default:
+      stage = 'repair_updates'
+      message = `${greeting}kami sedang menyemak status ${ticketLabel}.`
+      break
+  }
+
+  return {
+    stage,
+    text: `${message} ${formatMenuFooter()}`.trim(),
+  }
+}
+
+export interface ApprovalMessageContext {
+  ticketNumber: string
+  customerName?: string | null
+  estimatedCost?: string | null
+}
+
+export function formatApprovalAcceptedMessage(context: ApprovalMessageContext): string {
+  const name = context.customerName?.trim()
+  const greeting = name ? `Terima kasih ${name}!` : 'Terima kasih!'
+  const costPart = context.estimatedCost ? ` Anggaran kos kekal pada ${context.estimatedCost}.` : ''
+
+  return `${greeting} Kelulusan anda untuk tiket #${context.ticketNumber} telah direkodkan. Pasukan kami akan mula pembaikan serta berkongsi kemas kini penting melalui WhatsApp.${costPart} ${formatMenuFooter()}`.trim()
+}
+
+export interface RejectionMessageContext {
+  ticketNumber: string
+  customerName?: string | null
+}
+
+export function formatApprovalRejectedMessage(context: RejectionMessageContext): string {
+  const name = context.customerName?.trim()
+  const prefix = name ? `Baik ${name},` : 'Baik,'
+
+  return `${prefix} kami hentikan pembaikan untuk tiket #${context.ticketNumber} seperti permintaan anda. Hubungi kami bila-bila masa jika mahu menukar keputusan. ${formatMenuFooter()}`.trim()
+}
+
+export interface InvoiceSummaryContext {
+  ticketNumber: string
+  invoiceNumber?: string | null
+  invoiceTotal?: string | null
+  invoiceStatus?: string | null
+}
+
+export interface InvoiceSummaryResult {
+  stage: SopStage
+  text: string
+}
+
+export function formatInvoiceSummary(context: InvoiceSummaryContext): InvoiceSummaryResult {
+  if (!context.invoiceNumber) {
+    return {
+      stage: 'done_invoice',
+      text: `Invois untuk tiket #${context.ticketNumber} belum tersedia lagi. Kami akan maklumkan sebaik sahaja ia siap. ${formatMenuFooter()}`.trim(),
+    }
+  }
+
+  const parts = [`Invois #${context.invoiceNumber} untuk tiket #${context.ticketNumber} sudah tersedia.`]
+  if (context.invoiceTotal) {
+    parts.push(`Jumlah perlu dibayar: ${context.invoiceTotal}.`)
+  }
+  if (context.invoiceStatus) {
+    parts.push(`Status bayaran terkini: ${context.invoiceStatus}.`)
+  }
+
+  return {
+    stage: 'done_invoice',
+    text: `${parts.join(' ')} ${formatMenuFooter()}`.trim(),
+  }
+}
+
+export interface PickupInstructionsContext {
+  ticketNumber: string
+  status: TicketStatus
+  customerName?: string | null
+  invoiceStatus?: string | null
+  invoiceTotal?: string | null
+}
+
+export interface PickupInstructionsResult {
+  stage: SopStage
+  text: string
+}
+
+export function formatPickupInstructions(context: PickupInstructionsContext): PickupInstructionsResult {
+  const name = context.customerName?.trim()
+  const greeting = name ? `${name}, ` : ''
+  const ticketLabel = `tiket #${context.ticketNumber}`
+
+  if (context.status === 'done') {
+    const invoicePart = context.invoiceTotal
+      ? ` Jumlah invois: ${context.invoiceTotal}${context.invoiceStatus ? ` (${context.invoiceStatus})` : ''}.`
+      : ''
+
+    return {
+      stage: 'pickup_ready',
+      text: `${greeting}peranti untuk ${ticketLabel} sedia untuk diambil di kaunter kami. Bawa tiket ini semasa pengambilan.${invoicePart} ${formatMenuFooter()}`.trim(),
+    }
+  }
+
+  if (context.status === 'picked_up') {
+    return {
+      stage: 'pickup_complete',
+      text: `${greeting}terima kasih kerana mengambil semula peranti bagi ${ticketLabel}. Kami hargai jika anda boleh tinggalkan review apabila ada masa. ${formatMenuFooter()}`.trim(),
+    }
+  }
+
+  if (context.status === 'awaiting_approval') {
+    return {
+      stage: 'awaiting_approval',
+      text: `${greeting}kami masih menunggu kelulusan anda untuk ${ticketLabel}. Balas "setuju" untuk kami teruskan atau "tak setuju" jika mahu menangguhkan. ${formatMenuFooter()}`.trim(),
+    }
+  }
+
+  if (context.status === 'rejected') {
+    return {
+      stage: 'awaiting_approval',
+      text: `${greeting}pembaikan untuk ${ticketLabel} telah dihentikan mengikut arahan anda. Hubungi kami jika mahu mengaktifkan semula tiket. ${formatMenuFooter()}`.trim(),
+    }
+  }
+
+  const progressLabel =
+    context.status === 'repairing'
+      ? 'sedang dibaiki'
+      : context.status === 'approved'
+        ? 'dijadualkan untuk dibaiki'
+        : 'sedang diproses'
+
+  return {
+    stage: 'repair_updates',
+    text: `${greeting}peranti untuk ${ticketLabel} belum sedia untuk pickup lagi — statusnya ${progressLabel}. Kami akan maklumkan sebaik sahaja siap. ${formatMenuFooter()}`.trim(),
+  }
+}
+
+export function formatSupportHandoffMessage(customerName?: string | null): string {
+  const name = customerName?.trim()
+  const prefix = name ? `Baik ${name},` : 'Baik,'
+
+  return `${prefix} kami akan maklumkan staf kami untuk menghubungi anda secepat mungkin. ${formatMenuFooter()}`.trim()
+}
+
+export function formatNoTicketMessage(): string {
+  return 'Maaf, kami tidak menemui tiket aktif yang berkait dengan nombor ini. Sila hubungi kaunter kami untuk bantuan lanjut.'
+}
+
+export function formatUnknownCommandMessage(): string {
+  return `Maaf, kami tidak pasti permintaan anda. ${formatMenuFooter()}`.trim()
+}
+
+export function stageFromTicketStatus(status: TicketStatus | null | undefined): SopStage {
+  switch (status) {
+    case 'intake':
+      return 'intake_ack'
+    case 'diagnosed':
+      return 'diagnosis_summary'
+    case 'awaiting_approval':
+    case 'rejected':
+      return 'awaiting_approval'
+    case 'approved':
+    case 'repairing':
+      return 'repair_updates'
+    case 'done':
+      return 'done_invoice'
+    case 'picked_up':
+      return 'pickup_complete'
+    default:
+      return 'repair_updates'
+  }
 }


### PR DESCRIPTION
## Summary
- redesign the WhatsApp SOP helper to model each workflow stage and provide Malay messaging templates
- teach the WhatsApp webhook to resolve tickets, process menu commands (1/2/3, setuju/tak setuju), update statuses, and dispatch stage templates
- align workflow stage identifiers across diagnostics, ticket updates, reminders, and outbound messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9116eace8832b97693fbf6a16c274