### PR TITLE
Send SOP ticket reminders through workflow messaging

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,5 +1,10 @@
+import env from '@/env.mjs'
 import { startTicketApprovalReminderCron } from '@/lib/scheduler'
 
 export async function register(): Promise<void> {
+  if (!env.ENABLE_TICKET_APPROVAL_REMINDERS) {
+    return
+  }
+
   startTicketApprovalReminderCron()
 }

--- a/wa/index.js
+++ b/wa/index.js
@@ -235,8 +235,12 @@ app.post('/send', async (req, res) => {
     }
 
     const jid = ensureWhatsAppJid(to);
-    await client.sendMessage(jid, { text });
-    res.json({ success: true });
+    const result = await client.sendMessage(jid, { text });
+    res.json({
+      success: true,
+      messageId: result?.key?.id || null,
+      status: result?.status || 'sent',
+    });
   } catch (error) {
     logger.error({ err: error }, 'Failed to send message');
     res.status(500).json({ error: 'Failed to send message' });


### PR DESCRIPTION
## Summary
- send ticket approval reminders via the workflow WhatsApp helper so messages are dispatched before logging
- persist outbound and reminder log records with gateway-provided message ids/status and dedupe by SOP reminder kinds
- gate the reminder cron start on configuration and surface message metadata from the WA gateway

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d914954ec8832bbdf51984f112f189